### PR TITLE
Update BusinessdayCalendarExcludingTARGETHolidays.java

### DIFF
--- a/src/main/java/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
+++ b/src/main/java/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
@@ -53,6 +53,7 @@ public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalen
 				&&	!(day == 25 && month == 12)		// date is Christmas
 				&&	!(day == 26 && month == 12)		// date is Boxing Day
 				&&	!(day == 31 && month == 12)
+				&&	!(day ==  1 && month ==  5)		// date is Labour Dya
 				&&	!isEasterSunday(datePlus2)		// date is Good Friday
 				&&	!isEasterSunday(dateBefore)		// date is Easter Monday
 				;


### PR DESCRIPTION
Fix to include Labour Day as a holiday in the TARGET calender.
(Source: http://www.ecb.europa.eu/press/pr/date/2000/html/pr001214_4.en.html
and http://www.vdb.de/target-arbeitstage.aspx)
