### PR TITLE
Control default behavior with system properties

### DIFF
--- a/src/main/java/net/finmath/functions/LinearAlgebra.java
+++ b/src/main/java/net/finmath/functions/LinearAlgebra.java
@@ -35,6 +35,11 @@ import cern.colt.matrix.linalg.EigenvalueDecomposition;
  */
 public class LinearAlgebra {
 	
+
+	private static boolean isUseApacheCommonsMath() {
+		return Boolean.getBoolean("finmath.useCommonsMath");
+	}
+
 	/**
 	 * Find a solution of the linear equation A x = b where
 	 * <ul>
@@ -83,8 +88,7 @@ public class LinearAlgebra {
 	 * @return A solution x to A x = b.
 	 */
 	public static double[] solveLinearEquationSymmetric(double[][] matrix, double[] vector) {
-		boolean  isUseApacheCommonsMath = true;
-		if(isUseApacheCommonsMath) {
+		if(isUseApacheCommonsMath()) {
 			// We use the linear algebra package apache commons math
 			DecompositionSolver solver = new CholeskyDecomposition(new Array2DRowRealMatrix(matrix, false)).getSolver();
 			return solver.solve(new ArrayRealVector(vector)).toArray();
@@ -121,8 +125,7 @@ public class LinearAlgebra {
 	 * @return Matrix of n Eigenvectors (columns) (matrix is given as double[n][numberOfFactors], where n is the number of rows of the correlationMatrix.
 	 */
 	public static double[][] getFactorMatrix(double[][] correlationMatrix, int numberOfFactors) {
-		boolean  isUseApacheCommonsMath = false;
-		if(isUseApacheCommonsMath) {
+		if(isUseApacheCommonsMath()) {
 			/*
 			 * Note: Commons math has convergence problems, where Colt does not.
 			 */
@@ -141,8 +144,7 @@ public class LinearAlgebra {
 	 * @return Factor reduced correlation matrix.
 	 */
 	public static double[][] factorReduction(double[][] correlationMatrix, int numberOfFactors) {
-		boolean  isUseApacheCommonsMath = true;
-		if(isUseApacheCommonsMath) {
+		if(isUseApacheCommonsMath()) {
 			return factorReductionUsingCommonsMath(correlationMatrix, numberOfFactors);
 		}
 		else {

--- a/src/main/java/net/finmath/marketdata/calibration/CalibratedCurves.java
+++ b/src/main/java/net/finmath/marketdata/calibration/CalibratedCurves.java
@@ -366,6 +366,10 @@ public class CalibratedCurves {
 		this(calibrationSpecs, null, 0.0);
 	}
 
+	private static boolean isUseForwardCurve(){
+		return Boolean.parseBoolean(System.getProperty("finmath.useForwardCurve","true"));
+	}
+
 	public AnalyticProductInterface getCalibrationProductForSpec(CalibrationSpec calibrationSpec) {
 		createDiscountCurve(calibrationSpec.discountCurveReceiverName);
 		createDiscountCurve(calibrationSpec.discountCurvePayerName);
@@ -549,8 +553,7 @@ public class CalibratedCurves {
 		CurveInterface	forwardCurve = null;
 		if(curve == null) {
 			// Create a new forward curve
-			boolean isUseForwardCurve = true;
-			if(isUseForwardCurve) {
+			if(isUseForwardCurve()) {
 				curve = new ForwardCurve(forwardCurveName, swapTenorDefinition.getReferenceDate(), indexMaturityCode, ForwardCurve.InterpolationEntityForward.FORWARD, null);
 			}
 			else {

--- a/src/main/java/net/finmath/montecarlo/interestrate/LIBORMarketModelStandard.java
+++ b/src/main/java/net/finmath/montecarlo/interestrate/LIBORMarketModelStandard.java
@@ -211,6 +211,10 @@ public class LIBORMarketModelStandard extends AbstractModel implements LIBORMark
 		this.covarianceModel    = covarianceModelParametric.getCloneCalibrated(this, calibrationProducts, calibrationTargetValues, calibrationWeights);
 	}
 
+	private static boolean isUseAnalyticApproximation(){
+		return Boolean.parseBoolean(System.getProperty("finmath.useAnalyticApproximation","true"));
+	}
+
 	private static CalibrationItem[] getCalibrationItems(TimeDiscretizationInterface liborPeriodDiscretization, ForwardCurveInterface forwardCurve, AbstractSwaptionMarketData swaptionMarketData) {
 		if(swaptionMarketData == null) return null;
 		
@@ -253,8 +257,7 @@ public class LIBORMarketModelStandard extends AbstractModel implements LIBORMark
 					swaprates[periodStartIndex] = swaprate;
 				}
 
-				boolean isUseAnalyticApproximation = true;
-				if(isUseAnalyticApproximation) {
+				if(isUseAnalyticApproximation()) {
 					AbstractLIBORMonteCarloProduct swaption = new SwaptionAnalyticApproximation(swaprate, swapTenorTimes, SwaptionAnalyticApproximation.ValueUnit.VOLATILITY);
 					double impliedVolatility = swaptionMarketData.getVolatility(exerciseDate, swapLength, swaptionMarketData.getSwapPeriodLength(), swaprate);
 

--- a/src/main/java6/net/finmath/functions/LinearAlgebra.java
+++ b/src/main/java6/net/finmath/functions/LinearAlgebra.java
@@ -34,7 +34,11 @@ import cern.colt.matrix.linalg.EigenvalueDecomposition;
  * @version 1.5
  */
 public class LinearAlgebra {
-	
+
+	private static boolean isUseApacheCommonsMath() {
+		return Boolean.getBoolean("finmath.useCommonsMath");
+	}
+
 	/**
 	 * Find a solution of the linear equation A x = b where
 	 * <ul>
@@ -83,8 +87,7 @@ public class LinearAlgebra {
 	 * @return A solution x to A x = b.
 	 */
 	public static double[] solveLinearEquationSymmetric(double[][] matrix, double[] vector) {
-		boolean  isUseApacheCommonsMath = true;
-		if(isUseApacheCommonsMath) {
+		if(isUseApacheCommonsMath()) {
 			// We use the linear algebra package apache commons math
 			DecompositionSolver solver = new CholeskyDecomposition(new Array2DRowRealMatrix(matrix, false)).getSolver();
 			return solver.solve(new ArrayRealVector(vector)).toArray();
@@ -121,8 +124,7 @@ public class LinearAlgebra {
 	 * @return Matrix of n Eigenvectors (columns) (matrix is given as double[n][numberOfFactors], where n is the number of rows of the correlationMatrix.
 	 */
 	public static double[][] getFactorMatrix(double[][] correlationMatrix, int numberOfFactors) {
-		boolean  isUseApacheCommonsMath = false;
-		if(isUseApacheCommonsMath) {
+		if(isUseApacheCommonsMath()) {
 			/*
 			 * Note: Commons math has convergence problems, where Colt does not.
 			 */
@@ -290,21 +292,21 @@ public class LinearAlgebra {
 		// Extract factors corresponding to the largest eigenvalues
 		DoubleMatrix2D factorMatrix = getFactorMatrixUsingColt(correlationMatrix, numberOfFactors);
 
-		// Renormalized rows
 		for (int row = 0; row < factorMatrix.rows(); row++) {
 			double sumSquared = 0;
 			for (int factor = 0; factor < factorMatrix.columns(); factor++)
 				sumSquared += factorMatrix.get(row, factor) * factorMatrix.get(row, factor);
 			if(sumSquared != 0) {
-			    for (int factor = 0; factor < factorMatrix.columns(); factor++)
+				for (int factor = 0; factor < factorMatrix.columns(); factor++)
 					factorMatrix.set(row, factor, factorMatrix.get(row, factor) / Math.sqrt(sumSquared));
 			}
 			else {
-			    // This is a rare case: The factor reduction of a completely decorrelated system to 1 factor
-			    for (int factor = 0; factor < factorMatrix.columns(); factor++)
-					factorMatrix.set(row, factor, 1.0);			    
+				// This is a rare case: The factor reduction of a completely decorrelated system to 1 factor
+				for (int factor = 0; factor < factorMatrix.columns(); factor++)
+					factorMatrix.set(row, factor, 1.0);
 			}
 		}
+		// Renormalized rows
 
 		// Orthogonalized again
 		cern.colt.matrix.linalg.Algebra alg = new cern.colt.matrix.linalg.Algebra();

--- a/src/main/java6/net/finmath/marketdata/calibration/CalibratedCurves.java
+++ b/src/main/java6/net/finmath/marketdata/calibration/CalibratedCurves.java
@@ -319,6 +319,10 @@ public class CalibratedCurves {
 		this(calibrationSpecs, calibrationModel, 0.0, calibrationAccuracy);
 	}
 
+	private static boolean isUseForwardCurve(){
+		return Boolean.parseBoolean(System.getProperty("finmath.useForwardCurve","true"));
+	}
+
 	/**
 	 * Generate a collection of calibrated curves (discount curves, forward curves)
 	 * from a vector of calibration products and a given model.
@@ -549,8 +553,7 @@ public class CalibratedCurves {
 		CurveInterface	forwardCurve = null;
 		if(curve == null) {
 			// Create a new forward curve
-			boolean isUseForwardCurve = true;
-			if(isUseForwardCurve) {
+			if(isUseForwardCurve()) {
 				curve = new ForwardCurve(forwardCurveName, swapTenorDefinition.getReferenceDate(), indexMaturityCode, ForwardCurve.InterpolationEntityForward.FORWARD, null);
 			}
 			else {

--- a/src/main/java6/net/finmath/montecarlo/interestrate/LIBORMarketModelStandard.java
+++ b/src/main/java6/net/finmath/montecarlo/interestrate/LIBORMarketModelStandard.java
@@ -211,6 +211,10 @@ public class LIBORMarketModelStandard extends AbstractModel implements LIBORMark
 		this.covarianceModel    = covarianceModelParametric.getCloneCalibrated(this, calibrationProducts, calibrationTargetValues, calibrationWeights);
 	}
 
+	private static boolean isUseAnalyticApproximation(){
+		return Boolean.parseBoolean(System.getProperty("finmath.useAnalyticApproximation","true"));
+	}
+
 	private static CalibrationItem[] getCalibrationItems(TimeDiscretizationInterface liborPeriodDiscretization, ForwardCurveInterface forwardCurve, AbstractSwaptionMarketData swaptionMarketData) {
 		if(swaptionMarketData == null) return null;
 		
@@ -253,8 +257,7 @@ public class LIBORMarketModelStandard extends AbstractModel implements LIBORMark
 					swaprates[periodStartIndex] = swaprate;
 				}
 
-				boolean isUseAnalyticApproximation = true;
-				if(isUseAnalyticApproximation) {
+				if(isUseAnalyticApproximation()) {
 					AbstractLIBORMonteCarloProduct swaption = new SwaptionAnalyticApproximation(swaprate, swapTenorTimes, SwaptionAnalyticApproximation.ValueUnit.VOLATILITY);
 					double impliedVolatility = swaptionMarketData.getVolatility(exerciseDate, swapLength, swaptionMarketData.getSwapPeriodLength(), swaprate);
 


### PR DESCRIPTION
Hi, 

I would like to introduce following three system properties to control the behaviours:

system properties | default value | description 
-------------------------|------------------|-------------------
finmath.useAnalyticApproximation | true | whether  LIBORMarketModelStandard should be constructed with analytic approximation. 
finmath.useCommonsMath | false | whether LinearAlgebra should use commons-math. If it is false, COLT will be used instead. 
finmath.calibrateWithForwardCurve | true | whether CalibratedCurves should use forwardCurve.

Please kindly review the proposed changes. 

Best regards,
William