### PR TITLE
Overhaul of Schedule

### DIFF
--- a/src/main/java6/net/finmath/marketdata/model/curves/AbstractCurve.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/AbstractCurve.java
@@ -61,10 +61,6 @@ public abstract class AbstractCurve implements CurveInterface, Cloneable {
 		return values;
 	}
 
-	public String toString() {
-		return super.toString() + "\n\"" + this.getName() + "\"";
-	}
-
 	@Override
 	public AbstractCurve clone() throws CloneNotSupportedException {
 		return (AbstractCurve)super.clone();
@@ -73,5 +69,10 @@ public abstract class AbstractCurve implements CurveInterface, Cloneable {
 	@Override
 	public CurveInterface getCloneForParameter(double[] value) throws CloneNotSupportedException {
 		throw new CloneNotSupportedException();
+	}
+	
+	@Override
+	public String toString() {
+		return "AbstractCurve [name=" + name + ", referenceDate=" + referenceDate + "]";
 	}
 }

--- a/src/main/java6/net/finmath/marketdata/model/curves/AbstractForwardCurve.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/AbstractForwardCurve.java
@@ -12,9 +12,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.joda.time.LocalDate;
 
 import net.finmath.marketdata.model.AnalyticModelInterface;
-import net.finmath.time.Schedule;
+import net.finmath.time.FloatingpointDate;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface;
-import net.finmath.time.daycount.DayCountConvention_ACT_365;
 
 /**
  * Abstract base class for a forward curve, extending a curve object
@@ -121,11 +120,15 @@ public abstract class AbstractForwardCurve extends Curve implements ForwardCurve
 			return paymentOffsets.get(fixingTime);
 		}
 		else {
-			LocalDate paymentDate = paymentBusinessdayCalendar.getAdjustedDate(
-					getReferenceDate().plusDays((int)Math.round(fixingTime*365))
-					, paymentOffsetCode
-					, paymentDateRollConvention);
-			double paymentTime = Schedule.getInternalDaycountFraction(getReferenceDate(), paymentDate);
+			/**
+			 *  @TODO In case paymentDate is relevant for the index modeling, it should be checked
+			 *  if the following derivation of paymentDate is accurate (e.g. wo we have a fixingOffset).
+			 *  In such a case, this method may be overridden.
+			 */
+			LocalDate referenceDate = getReferenceDate();
+			LocalDate fixingDate = FloatingpointDate.getDateFromFloatingPointDate(referenceDate, fixingTime);
+			LocalDate paymentDate = paymentBusinessdayCalendar.getAdjustedDate(fixingDate, paymentOffsetCode, paymentDateRollConvention);
+			double paymentTime = FloatingpointDate.getFloatingPointDateFromDate(referenceDate, paymentDate);
 			paymentOffsets.put(fixingTime, paymentTime-fixingTime);
 			return paymentTime-fixingTime;
 		}

--- a/src/main/java6/net/finmath/marketdata/model/curves/AbstractForwardCurve.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/AbstractForwardCurve.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.joda.time.LocalDate;
 
 import net.finmath.marketdata.model.AnalyticModelInterface;
+import net.finmath.time.Schedule;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface;
 import net.finmath.time.daycount.DayCountConvention_ACT_365;
 
@@ -124,7 +125,7 @@ public abstract class AbstractForwardCurve extends Curve implements ForwardCurve
 					getReferenceDate().plusDays((int)Math.round(fixingTime*365))
 					, paymentOffsetCode
 					, paymentDateRollConvention);
-			double paymentTime = (new DayCountConvention_ACT_365()).getDaycountFraction(getReferenceDate(), paymentDate);
+			double paymentTime = Schedule.getInternalDaycountFraction(getReferenceDate(), paymentDate);
 			paymentOffsets.put(fixingTime, paymentTime-fixingTime);
 			return paymentTime-fixingTime;
 		}

--- a/src/main/java6/net/finmath/marketdata/model/curves/Curve.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/Curve.java
@@ -7,6 +7,7 @@ package net.finmath.marketdata.model.curves;
 
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
+import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -18,7 +19,7 @@ import org.joda.time.LocalDate;
 
 import net.finmath.interpolation.RationalFunctionInterpolation;
 import net.finmath.marketdata.model.AnalyticModelInterface;
-import net.finmath.time.Schedule;
+import net.finmath.time.FloatingpointDate;
 
 /**
  * This class represents a curve build from a set of points in 2D.
@@ -486,12 +487,23 @@ public class Curve extends AbstractCurve implements Serializable, Cloneable {
 		CurveBuilder curveBuilder = new CurveBuilder(this);
 		return curveBuilder;
 	}
-	
+
 	@Override
 	public String toString() {
-		String pointsAsString = "";
-		for (Point point : points)
-			pointsAsString += "\n[" + Schedule.getDateFromDouble(getReferenceDate(),point.time) + ": " + valueFromInterpolationEntity(point.value, point.time) + "]";
-		return "Curve [" + super.toString() + ", interpolationMethod=" + interpolationMethod + ", interpolationEntity=" + interpolationEntity + ", extrapolationMethod=" + extrapolationMethod + ", " + (points.size()==0?"no points":"points: " + pointsAsString) + "]";
+		/*
+		 * Pretty print curve (appended to standard toString)
+		 */
+		StringBuilder curveTableString = new StringBuilder();
+		NumberFormat formatTime = new DecimalFormat("0.00000000E0");	// Floating point time is accurate to 3+5 digits.
+		for (Point point : points) {
+			curveTableString.append(formatTime.format(point.time) + "\t");
+			curveTableString.append(FloatingpointDate.getDateFromFloatingPointDate(getReferenceDate(), point.time) + "\t");
+			curveTableString.append(valueFromInterpolationEntity(point.value, point.time) + "\n");
+		}
+		
+		return "Curve [points=" + points + ", pointsBeingParameters=" + pointsBeingParameters + ", interpolationMethod="
+				+ interpolationMethod + ", extrapolationMethod=" + extrapolationMethod + ", interpolationEntity="
+				+ interpolationEntity + ", rationalFunctionInterpolation=" + rationalFunctionInterpolation
+				+ ", toString()=" + super.toString() + ",\n" + curveTableString + "]";
 	}
 }

--- a/src/main/java6/net/finmath/marketdata/model/curves/Curve.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/Curve.java
@@ -18,6 +18,7 @@ import org.joda.time.LocalDate;
 
 import net.finmath.interpolation.RationalFunctionInterpolation;
 import net.finmath.marketdata.model.AnalyticModelInterface;
+import net.finmath.time.Schedule;
 
 /**
  * This class represents a curve build from a set of points in 2D.
@@ -429,14 +430,6 @@ public class Curve extends AbstractCurve implements Serializable, Cloneable {
 		this.curveCacheReference = null;
 	}
 
-	public String toString() {
-		String objectAsString = super.toString() + "\n";
-		for (Point point : points) {
-			objectAsString = objectAsString + point.time + "\t" + valueFromInterpolationEntity(point.value, point.time) + "\n";
-		}
-		return objectAsString;
-	}
-
 	private double interpolationEntityFromValue(double value, double time) {
 		switch(interpolationEntity) {
 		case VALUE:
@@ -492,5 +485,13 @@ public class Curve extends AbstractCurve implements Serializable, Cloneable {
 	public CurveBuilderInterface getCloneBuilder() throws CloneNotSupportedException {
 		CurveBuilder curveBuilder = new CurveBuilder(this);
 		return curveBuilder;
+	}
+	
+	@Override
+	public String toString() {
+		String pointsAsString = "";
+		for (Point point : points)
+			pointsAsString += "\n[" + Schedule.getDateFromDouble(getReferenceDate(),point.time) + ": " + valueFromInterpolationEntity(point.value, point.time) + "]";
+		return "Curve [" + super.toString() + ", interpolationMethod=" + interpolationMethod + ", interpolationEntity=" + interpolationEntity + ", extrapolationMethod=" + extrapolationMethod + ", " + (points.size()==0?"no points":"points: " + pointsAsString) + "]";
 	}
 }

--- a/src/main/java6/net/finmath/marketdata/model/curves/CurveFactory.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/CurveFactory.java
@@ -16,6 +16,7 @@ import org.joda.time.LocalDate;
 import net.finmath.marketdata.model.curves.Curve.ExtrapolationMethod;
 import net.finmath.marketdata.model.curves.Curve.InterpolationEntity;
 import net.finmath.marketdata.model.curves.Curve.InterpolationMethod;
+import net.finmath.time.FloatingpointDate;
 import net.finmath.time.Schedule;
 import net.finmath.time.daycount.DayCountConvention_30E_360;
 import net.finmath.time.daycount.DayCountConvention_ACT_365;
@@ -139,7 +140,7 @@ public class CurveFactory {
 		 */
 		Double baseValue	= indexFixings.get(baseDate);
 		if(baseValue == null) throw new IllegalArgumentException("Curve " + name + " has missing index value for base date " + baseDate);
-		double baseTime		= Schedule.getInternalDaycountFraction(referenceDate, baseDate);
+		double baseTime		= FloatingpointDate.getFloatingPointDateFromDate(referenceDate, baseDate);
 
 		/*
 		 * Combine all three curves.

--- a/src/main/java6/net/finmath/marketdata/model/curves/CurveFactory.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/CurveFactory.java
@@ -16,6 +16,7 @@ import org.joda.time.LocalDate;
 import net.finmath.marketdata.model.curves.Curve.ExtrapolationMethod;
 import net.finmath.marketdata.model.curves.Curve.InterpolationEntity;
 import net.finmath.marketdata.model.curves.Curve.InterpolationMethod;
+import net.finmath.time.Schedule;
 import net.finmath.time.daycount.DayCountConvention_30E_360;
 import net.finmath.time.daycount.DayCountConvention_ACT_365;
 
@@ -138,7 +139,7 @@ public class CurveFactory {
 		 */
 		Double baseValue	= indexFixings.get(baseDate);
 		if(baseValue == null) throw new IllegalArgumentException("Curve " + name + " has missing index value for base date " + baseDate);
-		double baseTime		= (new DayCountConvention_ACT_365()).getDaycountFraction(referenceDate, baseDate);
+		double baseTime		= Schedule.getInternalDaycountFraction(referenceDate, baseDate);
 
 		/*
 		 * Combine all three curves.

--- a/src/main/java6/net/finmath/marketdata/model/curves/DiscountCurve.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/DiscountCurve.java
@@ -436,6 +436,6 @@ public class DiscountCurve extends Curve implements Serializable, DiscountCurveI
 
 	@Override
 	public String toString() {
-		return super.toString();
+		return "DiscountCurve [" + super.toString() + "]";
 	}
 }

--- a/src/main/java6/net/finmath/marketdata/model/curves/ForwardCurveNelsonSiegelSvensson.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/ForwardCurveNelsonSiegelSvensson.java
@@ -11,6 +11,7 @@ import org.joda.time.LocalDate;
 
 import net.finmath.marketdata.model.AnalyticModel;
 import net.finmath.marketdata.model.AnalyticModelInterface;
+import net.finmath.time.FloatingpointDate;
 import net.finmath.time.Schedule;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface;
 import net.finmath.time.daycount.DayCountConventionInterface;
@@ -164,7 +165,7 @@ public class ForwardCurveNelsonSiegelSvensson extends AbstractCurve implements S
 	public double getPaymentOffset(double fixingTime) {
 		LocalDate fixingDate		= getDateFromModelTime(fixingTime);
 		LocalDate paymentDate		= paymentBusinessdayCalendar.getAdjustedDate(fixingDate, paymentOffsetCode, paymentDateRollConvention);
-		double paymentTime = Schedule.getInternalDaycountFraction(getReferenceDate(), paymentDate);
+		double paymentTime = FloatingpointDate.getFloatingPointDateFromDate(getReferenceDate(), paymentDate);
 		return paymentTime-fixingTime;
 	}
 	

--- a/src/main/java6/net/finmath/marketdata/model/curves/ForwardCurveNelsonSiegelSvensson.java
+++ b/src/main/java6/net/finmath/marketdata/model/curves/ForwardCurveNelsonSiegelSvensson.java
@@ -11,6 +11,7 @@ import org.joda.time.LocalDate;
 
 import net.finmath.marketdata.model.AnalyticModel;
 import net.finmath.marketdata.model.AnalyticModelInterface;
+import net.finmath.time.Schedule;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface;
 import net.finmath.time.daycount.DayCountConventionInterface;
 import net.finmath.time.daycount.DayCountConvention_ACT_365;
@@ -163,7 +164,7 @@ public class ForwardCurveNelsonSiegelSvensson extends AbstractCurve implements S
 	public double getPaymentOffset(double fixingTime) {
 		LocalDate fixingDate		= getDateFromModelTime(fixingTime);
 		LocalDate paymentDate		= paymentBusinessdayCalendar.getAdjustedDate(fixingDate, paymentOffsetCode, paymentDateRollConvention);
-		double paymentTime = (new DayCountConvention_ACT_365()).getDaycountFraction(getReferenceDate(), paymentDate);
+		double paymentTime = Schedule.getInternalDaycountFraction(getReferenceDate(), paymentDate);
 		return paymentTime-fixingTime;
 	}
 	

--- a/src/main/java6/net/finmath/montecarlo/interestrate/products/indices/TimeDiscreteEndOfMonthIndex.java
+++ b/src/main/java6/net/finmath/montecarlo/interestrate/products/indices/TimeDiscreteEndOfMonthIndex.java
@@ -12,6 +12,7 @@ import org.joda.time.LocalDate;
 import net.finmath.exception.CalculationException;
 import net.finmath.montecarlo.interestrate.LIBORModelMonteCarloSimulationInterface;
 import net.finmath.stochastic.RandomVariableInterface;
+import net.finmath.time.Schedule;
 import net.finmath.time.daycount.DayCountConvention_ACT_365;
 
 /**
@@ -50,7 +51,7 @@ public class TimeDiscreteEndOfMonthIndex extends AbstractIndex {
 				.plusMonths(fixingOffsetMonths);
 
 		endDate = endDate.withDayOfMonth(endDate.dayOfMonth().getMaximumValue());
-		double time = (new DayCountConvention_ACT_365()).getDaycountFraction(referenceDate, endDate);
+		double time = Schedule.getInternalDaycountFraction(referenceDate, endDate);
 		return baseIndex.getValue(time, model);
 	}
 

--- a/src/main/java6/net/finmath/montecarlo/interestrate/products/indices/TimeDiscreteEndOfMonthIndex.java
+++ b/src/main/java6/net/finmath/montecarlo/interestrate/products/indices/TimeDiscreteEndOfMonthIndex.java
@@ -12,6 +12,7 @@ import org.joda.time.LocalDate;
 import net.finmath.exception.CalculationException;
 import net.finmath.montecarlo.interestrate.LIBORModelMonteCarloSimulationInterface;
 import net.finmath.stochastic.RandomVariableInterface;
+import net.finmath.time.FloatingpointDate;
 import net.finmath.time.Schedule;
 import net.finmath.time.daycount.DayCountConvention_ACT_365;
 
@@ -45,13 +46,15 @@ public class TimeDiscreteEndOfMonthIndex extends AbstractIndex {
 
 		LocalDate referenceDate = model.getModel().getForwardRateCurve().getReferenceDate();
 
-		LocalDate endDate = referenceDate
-				.plusDays((int)Math.round(evaluationTime * 365))
-				.withDayOfMonth(1)
-				.plusMonths(fixingOffsetMonths);
+		LocalDate evaluationDate = FloatingpointDate.getDateFromFloatingPointDate(referenceDate, evaluationTime);
 
+		// Roll to start of month (to prevent "overflow)
+		LocalDate endDate = evaluationDate.withDayOfMonth(1).plusMonths(fixingOffsetMonths);
+
+		// Roll to end of month.
 		endDate = endDate.withDayOfMonth(endDate.dayOfMonth().getMaximumValue());
-		double time = Schedule.getInternalDaycountFraction(referenceDate, endDate);
+		
+		double time = FloatingpointDate.getFloatingPointDateFromDate(referenceDate, endDate);
 		return baseIndex.getValue(time, model);
 	}
 

--- a/src/main/java6/net/finmath/time/FloatingpointDate.java
+++ b/src/main/java6/net/finmath/time/FloatingpointDate.java
@@ -1,0 +1,64 @@
+/*
+ * (c) Copyright Christian P. Fries, Germany. Contact: email@christianfries.com.
+ *
+ * Created on 16.05.2017
+ */
+package net.finmath.time;
+
+
+import org.joda.time.LocalDate;
+
+import net.finmath.time.daycount.DayCountConventionInterface;
+import net.finmath.time.daycount.DayCountConvention_ACT_365;
+
+/**
+ * This class provides the library wide conversion from a floating point number to a LocalDate.
+ * 
+ * While in practical applications a date or time should always be represented with a proper
+ * date class, e.g. <code>LocalDate</code>. In financial applications the measurement
+ * of time distances has to be based on a solid definition, e.g., daycount conventions to calculate
+ * daycount fractions.
+ * 
+ * However, many mathematical models described in text books rely on time being model as some
+ * real value \( t \).
+ * 
+ * To allow for both approaches to co-exists this class fixes the interpretation of a floating
+ * point number representing time, <i>unless otherwise specified</i>.
+ * 
+ * So it still possible that models use their own "conversion".
+ * 
+ * Examples where the specification of this contract is important:
+ * - the way of measuring time in an NSS curve determines the interpretation of the NSS parameters.
+ * - in the textbook Black-Scholes models, multiplying volatility by W(t), changing from an ACT/365 to ACT/360 would represent a re-scaling of the volatilities.
+ * 
+ * @author Christian Fries
+ */
+public class FloatingpointDate {
+
+	private static	DayCountConventionInterface	internalDayCounting = new DayCountConvention_ACT_365();
+	
+	/**
+	 * Convert a floating point date to a LocalDate.
+	 * 
+	 * Note: This method currently performs a rounding to the next day.
+	 * In a future extension intra-day time offsets may be considered.
+	 * 
+	 * @param referenceDate The reference date associated with \( t=0 \).
+	 * @param floatingPointDate The value to the time offset \( t \).
+	 * @return The date resulting from adding Math.round(fixingTime*365.0) days to referenceDate.
+	 */
+	public static LocalDate getDateFromFloatingPointDate(LocalDate referenceDate, double floatingPointDate) {
+		return referenceDate.plusDays((int)Math.round(floatingPointDate*365.0));
+	}
+	
+	/**
+	 * Convert a given date to a floating point date using a given reference date.
+	 * 
+	 * @param referenceDate The reference date associated with \( t=0 \).
+	 * @param date The given daten to be associated with the return value \( T \).
+	 * @return The value T measuring the distance of reference date and date by ACT/365.
+	 */
+	public static double getFloatingPointDateFromDate(LocalDate referenceDate, LocalDate date) {
+		return internalDayCounting.getDaycountFraction(referenceDate, date);
+	}
+}

--- a/src/main/java6/net/finmath/time/FloatingpointDate.java
+++ b/src/main/java6/net/finmath/time/FloatingpointDate.java
@@ -43,11 +43,14 @@ public class FloatingpointDate {
 	 * Note: This method currently performs a rounding to the next day.
 	 * In a future extension intra-day time offsets may be considered.
 	 * 
+	 * If referenceDate is null, the method returns null.
+	 * 
 	 * @param referenceDate The reference date associated with \( t=0 \).
 	 * @param floatingPointDate The value to the time offset \( t \).
 	 * @return The date resulting from adding Math.round(fixingTime*365.0) days to referenceDate.
 	 */
 	public static LocalDate getDateFromFloatingPointDate(LocalDate referenceDate, double floatingPointDate) {
+		if(referenceDate == null) return null;
 		return referenceDate.plusDays((int)Math.round(floatingPointDate*365.0));
 	}
 	

--- a/src/main/java6/net/finmath/time/Period.java
+++ b/src/main/java6/net/finmath/time/Period.java
@@ -104,8 +104,6 @@ public class Period implements Comparable<Period> {
 
 	@Override
 	public String toString() {
-		return "Period [fixing=" + fixing + ", payment=" + payment
-				+ ", periodStart=" + periodStart + ", periodEnd=" + periodEnd
-				+ "]";
+		return "Period [start=" + periodStart + ", end=" + periodEnd + ", fixing=" + fixing + ", payment=" + payment + "]";
 	}
 }

--- a/src/main/java6/net/finmath/time/Schedule.java
+++ b/src/main/java6/net/finmath/time/Schedule.java
@@ -29,7 +29,6 @@ import net.finmath.time.daycount.DayCountConvention_ACT_365;
  */
 public class Schedule implements ScheduleInterface {
 
-	private static	DayCountConventionInterface	internalDayCounting = new DayCountConvention_ACT_365();
 	private			LocalDate					referenceDate;
 
 	private List<Period>			periods;
@@ -58,10 +57,10 @@ public class Schedule implements ScheduleInterface {
 		periodEndTimes = new double[periods.size()];
 		periodLength = new double[periods.size()];
 		for(int periodIndex=0; periodIndex < periods.size(); periodIndex++) {
-			fixingTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getFixing());
-			paymentTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPayment());
-			periodStartTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodStart());
-			periodEndTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodEnd());
+			fixingTimes[periodIndex] = FloatingpointDate.getFloatingPointDateFromDate(referenceDate, periods.get(periodIndex).getFixing());
+			paymentTimes[periodIndex] = FloatingpointDate.getFloatingPointDateFromDate(referenceDate, periods.get(periodIndex).getPayment());
+			periodStartTimes[periodIndex] = FloatingpointDate.getFloatingPointDateFromDate(referenceDate, periods.get(periodIndex).getPeriodStart());
+			periodEndTimes[periodIndex] = FloatingpointDate.getFloatingPointDateFromDate(referenceDate, periods.get(periodIndex).getPeriodEnd());
 			periodLength[periodIndex] = daycountconvention.getDaycountFraction(periods.get(periodIndex).getPeriodStart(), periods.get(periodIndex).getPeriodEnd());
 		}
 	}
@@ -122,34 +121,6 @@ public class Schedule implements ScheduleInterface {
 	@Override
 	public Iterator<Period> iterator() {
 		return periods.iterator();
-	}
-	
-	/**
-	 * Creates a date by adding a double dateOffset (Act/365) to a reference date
-	 * 
-	 * @param referenceDate reference date to add dateOffset to
-	 * @param dateOffset dateOffset stored as a double with Act/365 convention
-	 * @return The date resulting from adding a double dateOffset (Act/365) to a reference date
-	 */
-	public static LocalDate getDateFromDouble(LocalDate referenceDate, double dateOffset) {
-		if(!(internalDayCounting instanceof DayCountConvention_ACT_365))
-			throw new IllegalArgumentException("Method expects ACT/365 as internalDayCounting, not " + internalDayCounting);
-		int numberOfDays = (int)(dateOffset*365);
-		double remainder = dateOffset - numberOfDays;
-		if(remainder > 1E-16)
-			throw new IllegalArgumentException("Cannot add double " + dateOffset + " to date " + referenceDate + " as this is not an Act/365 double (dateOffset-(int)(dateOffset*365)=" + remainder + ")");
-		
-		LocalDate returnDate = referenceDate.plusDays(numberOfDays);	
-		return returnDate;
-	}
-	
-	/**
-	 * @param startDate Start date to calculate daycount fraction from
-	 * @param endDate End date to calculate daycount fraction to
-	 * @return the daycount fraction corresponding to the period from startDate to endDate given the internalDayCounting convention.
-	 */
-	public static double getInternalDaycountFraction(LocalDate startDate, LocalDate endDate) {
-		return internalDayCounting.getDaycountFraction(startDate, endDate);
 	}
 	
 	@Override

--- a/src/main/java6/net/finmath/time/Schedule.java
+++ b/src/main/java6/net/finmath/time/Schedule.java
@@ -29,7 +29,7 @@ import net.finmath.time.daycount.DayCountConvention_ACT_365;
  */
 public class Schedule implements ScheduleInterface {
 
-	private static	DayCountConventionInterface	internalDayCounting = new DayCountConvention_ACT_365();
+	public static	DayCountConventionInterface	internalDayCounting = new DayCountConvention_ACT_365(); // static internal daycount convention to convert between doubles and date diffs
 	private			LocalDate					referenceDate;
 
 	private List<Period>			periods;
@@ -58,11 +58,11 @@ public class Schedule implements ScheduleInterface {
 		periodEndTimes = new double[periods.size()];
 		periodLength = new double[periods.size()];
 		for(int periodIndex=0; periodIndex < periods.size(); periodIndex++) {
-			fixingTimes[periodIndex] = internalDayCounting.getDaycountFraction(referenceDate, periods.get(periodIndex).getFixing());
-			paymentTimes[periodIndex] = internalDayCounting.getDaycountFraction(referenceDate, periods.get(periodIndex).getPayment());
-			periodStartTimes[periodIndex] = internalDayCounting.getDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodStart());
-			periodEndTimes[periodIndex] = internalDayCounting.getDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodEnd());
-			periodLength[periodIndex] = daycountconvention.getDaycountFraction(periods.get(periodIndex).getPeriodStart(), periods.get(periodIndex).getPeriodEnd());
+			fixingTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getFixing());
+			paymentTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPayment());
+			periodStartTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodStart());
+			periodEndTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodEnd());
+			periodLength[periodIndex] = getInternalDaycountFraction(periods.get(periodIndex).getPeriodStart(), periods.get(periodIndex).getPeriodEnd());
 		}
 	}
 
@@ -116,13 +116,6 @@ public class Schedule implements ScheduleInterface {
 		return periodLength[periodIndex];
 	}
 
-	@Override
-	public String toString() {
-		return "Schedule [referenceDate=" + referenceDate + ", periods="
-				+ periods + ", daycountconvention=" + daycountconvention + "]";
-	}
-
-
 	/* (non-Javadoc)
 	 * @see java.lang.Iterable#iterator()
 	 */
@@ -130,5 +123,43 @@ public class Schedule implements ScheduleInterface {
 	public Iterator<Period> iterator() {
 		return periods.iterator();
 	}
-
+	
+	/**
+	 * Creates a date by adding a double dateOffset (Act/365) to a reference date
+	 * 
+	 * @param referenceDate reference date to add dateOffset to
+	 * @param dateOffset dateOffset stored as a double with Act/365 convention
+	 * @return The date resulting from adding a double dateOffset (Act/365) to a reference date
+	 */
+	public static LocalDate getDateFromDouble(LocalDate referenceDate, double dateOffset) {
+		if(!(internalDayCounting instanceof DayCountConvention_ACT_365))
+			throw new IllegalArgumentException("Method expects ACT/365 as internalDayCounting, not " + internalDayCounting);
+		int numberOfDays = (int)(dateOffset*365);
+		double remainder = dateOffset - numberOfDays;
+		if(remainder > 1E-16)
+			throw new IllegalArgumentException("Cannot add double " + dateOffset + " to date " + referenceDate + " as this is not an Act/365 double (dateOffset-(int)(dateOffset*365)=" + remainder + ")");
+		
+		LocalDate returnDate = referenceDate.plusDays(numberOfDays);	
+		return returnDate;
+	}
+	
+	/**
+	 * @param startDate Start date to calculate daycount fraction from
+	 * @param endDate End date to calculate daycount fraction to
+	 * @return the daycount fraction corresponding to the period from startDate to endDate given the internalDayCounting convention.
+	 */
+	public static double getInternalDaycountFraction(LocalDate startDate, LocalDate endDate) {
+		return internalDayCounting.getDaycountFraction(startDate, endDate);
+	}
+	
+	@Override
+	public String toString() {
+		String periodOutputString = "Periods (fixing, periodStart, periodEnd, payment):";
+		for(int periodIndex=0; periodIndex<periods.size(); periodIndex++) 
+			periodOutputString += "\n" + periods.get(periodIndex).getFixing() + ", " +
+									periods.get(periodIndex).getPeriodStart() + ", " +
+									periods.get(periodIndex).getPeriodEnd() + ", " +
+									periods.get(periodIndex).getPayment();
+		return "Schedule [referenceDate=" + referenceDate + ", daycountconvention=" + daycountconvention + "\n" + periodOutputString + "]";
+	}
 }

--- a/src/main/java6/net/finmath/time/Schedule.java
+++ b/src/main/java6/net/finmath/time/Schedule.java
@@ -62,7 +62,7 @@ public class Schedule implements ScheduleInterface {
 			paymentTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPayment());
 			periodStartTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodStart());
 			periodEndTimes[periodIndex] = getInternalDaycountFraction(referenceDate, periods.get(periodIndex).getPeriodEnd());
-			periodLength[periodIndex] = getInternalDaycountFraction(periods.get(periodIndex).getPeriodStart(), periods.get(periodIndex).getPeriodEnd());
+			periodLength[periodIndex] = daycountconvention.getDaycountFraction(periods.get(periodIndex).getPeriodStart(), periods.get(periodIndex).getPeriodEnd());
 		}
 	}
 

--- a/src/main/java6/net/finmath/time/Schedule.java
+++ b/src/main/java6/net/finmath/time/Schedule.java
@@ -29,7 +29,7 @@ import net.finmath.time.daycount.DayCountConvention_ACT_365;
  */
 public class Schedule implements ScheduleInterface {
 
-	public static	DayCountConventionInterface	internalDayCounting = new DayCountConvention_ACT_365(); // static internal daycount convention to convert between doubles and date diffs
+	private static	DayCountConventionInterface	internalDayCounting = new DayCountConvention_ACT_365();
 	private			LocalDate					referenceDate;
 
 	private List<Period>			periods;

--- a/src/main/java6/net/finmath/time/Tenor.java
+++ b/src/main/java6/net/finmath/time/Tenor.java
@@ -44,7 +44,7 @@ public class Tenor extends TimeDiscretization implements TenorInterface {
 
 		for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
 			timeDiscretization[timeIndex] =
-					Schedule.getInternalDaycountFraction(referenceDate, dates[timeIndex]);
+					FloatingpointDate.getFloatingPointDateFromDate(referenceDate, dates[timeIndex]);
 		}
 
 		return timeDiscretization;

--- a/src/main/java6/net/finmath/time/Tenor.java
+++ b/src/main/java6/net/finmath/time/Tenor.java
@@ -8,9 +8,6 @@ package net.finmath.time;
 
 import org.joda.time.LocalDate;
 
-import net.finmath.time.daycount.DayCountConventionInterface;
-import net.finmath.time.daycount.DayCountConvention_ACT_365;
-
 /**
  * Implements a time discretization based on dates using a reference
  * date and an daycount convention / year fraction.
@@ -23,9 +20,7 @@ public class Tenor extends TimeDiscretization implements TenorInterface {
 
 	private static final long serialVersionUID = 4027884423439197483L;
 
-	private static	DayCountConventionInterface	internalDayCounting = new DayCountConvention_ACT_365();
 	private			LocalDate					referenceDate;
-
 	private 		LocalDate[]					dates;
 
 	/**
@@ -49,7 +44,7 @@ public class Tenor extends TimeDiscretization implements TenorInterface {
 
 		for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
 			timeDiscretization[timeIndex] =
-					internalDayCounting.getDaycountFraction(referenceDate, dates[timeIndex]);
+					Schedule.getInternalDaycountFraction(referenceDate, dates[timeIndex]);
 		}
 
 		return timeDiscretization;
@@ -122,5 +117,15 @@ public class Tenor extends TimeDiscretization implements TenorInterface {
 	@Override
 	public double getDaycountFraction(int timeIndex) {
 		return this.getTimeStep(timeIndex);
+	}
+	
+	@Override
+	public String toString() {
+		String datesOutputString = "[";
+		for(int iDate=0; iDate<dates.length; iDate++)
+			datesOutputString += dates[iDate].toString() + (iDate==dates.length-1 ? "" : ", ");
+		datesOutputString += "]";
+		
+		return "Tenor [referenceDate=" + referenceDate + ", dates=" + datesOutputString + "]";
 	}
 }

--- a/src/test/java6/net/finmath/marketdata/model/volatilities/CapletVolatilitiesParametricCalibrationTest.java
+++ b/src/test/java6/net/finmath/marketdata/model/volatilities/CapletVolatilitiesParametricCalibrationTest.java
@@ -156,7 +156,6 @@ public class CapletVolatilitiesParametricCalibrationTest {
 		Vector<AnalyticProductInterface>	marketProducts = new Vector<AnalyticProductInterface>();
 		ArrayList<Double>					marketTargetValues = new ArrayList<Double>();
 		LocalDate referenceDate = new LocalDate(2014, DateTimeConstants.JULY,  15);
-		DayCountConventionInterface modelDayCountConvention = new DayCountConvention_ACT_365();
 		DaycountConvention capDayCountConvention = DaycountConvention.ACT_360;
 		for(int i=0; i<maturities.length; i++) {
 			LocalDate	tradeDate		= referenceDate;


### PR DESCRIPTION
- Schedule: Made member internalDayCounting public. This is the internal
day count convention that should be used throughout the library
- Schedule: Added static method getDateFromDouble(LocalDate
referenceDate, double dateOffset) that creates a date by using the
internalDayCounting convention to add a dateOffset to a referenceDate
- Schedule: Added static method getInternalDaycountFraction(LocalDate
startDate, LocalDate endDate) to calculate the daycount fraction between
2 dates using the internalDayCounting convention
- Tenor: removed member internalDayCounting – use internalDayCounting of
Schedule instead
- AbstractForwardCurve ...: Replaced hardcoded Act_365 dcc with internal
dcc
- Schedule/Period/Tenor: Added or improved toString() method