### PR TITLE
Changes to ScheduleGenerator and BusinessdayCalendars:

### DIFF
--- a/src/main/java6/net/finmath/time/ScheduleGenerator.java
+++ b/src/main/java6/net/finmath/time/ScheduleGenerator.java
@@ -11,7 +11,6 @@ import java.util.Date;
 
 import org.joda.time.LocalDate;
 
-import net.finmath.time.businessdaycalendar.BusinessdayCalendar;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarAny;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface.DateRollConvention;
@@ -115,7 +114,7 @@ public class ScheduleGenerator {
 	}
 
 	/**
-	 * Schedule generation from meta data.
+	 * Schedule generation for given {referenceDate,startDate,maturityDate}.
 	 * 
 	 * Generates a schedule based on some meta data.
 	 * <ul>
@@ -127,8 +126,8 @@ public class ScheduleGenerator {
 	 * t = 0 corresponds to the reference date.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param startDate The start date of the first period.
-	 * @param maturity The end date of the first period.
+	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
+	 * @param maturityDate The end date of the first period (this may/should be an unadjusted date).
 	 * @param frequency The frequency.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
@@ -142,7 +141,7 @@ public class ScheduleGenerator {
 	public static ScheduleInterface createScheduleFromConventions(
 			LocalDate referenceDate,
 			LocalDate startDate,
-			LocalDate maturity,
+			LocalDate maturityDate,
 			Frequency frequency,
 			DaycountConvention daycountConvention,
 			ShortPeriodConvention shortPeriodConvention,
@@ -221,7 +220,7 @@ public class ScheduleGenerator {
 			LocalDate periodStartDate			= businessdayCalendar.getAdjustedDate(periodStartDateUnadjusted, dateRollConvention);
 
 			int periodIndex = 0;
-			while(periodStartDateUnadjusted.isBefore(maturity)) {
+			while(periodStartDateUnadjusted.isBefore(maturityDate)) {
 				periodIndex++;
 				// The following code only makes calculations on periodEndXxx while the periodStartXxx is only copied and used to check if we terminate
 				// Determine period end
@@ -239,9 +238,9 @@ public class ScheduleGenerator {
 							.plusWeeks(periodLengthWeeks*periodIndex)
 							.plusMonths(periodLengthMonth*periodIndex);
 				}
-				if(periodEndDateUnadjusted.isAfter(maturity)) {
-					periodEndDateUnadjusted 	= maturity;
-					periodStartDateUnadjusted 	= maturity;	// Terminate loop (next periodEndDateUnadjusted)
+				if(periodEndDateUnadjusted.isAfter(maturityDate)) {
+					periodEndDateUnadjusted 	= maturityDate;
+					periodStartDateUnadjusted 	= maturityDate;	// Terminate loop (next periodEndDateUnadjusted)
 				}
 
 				// Adjust period
@@ -268,8 +267,8 @@ public class ScheduleGenerator {
 			/*
 			 * Going backward on periodEndDate, starting with maturity as periodEndDate
 			 */
-			LocalDate periodStartDateUnadjusted	= maturity;
-			LocalDate periodEndDateUnadjusted	= maturity;
+			LocalDate periodStartDateUnadjusted	= maturityDate;
+			LocalDate periodEndDateUnadjusted	= maturityDate;
 			LocalDate periodEndDate				= businessdayCalendar.getAdjustedDate(periodEndDateUnadjusted, dateRollConvention);
 			
 			int periodIndex = 0;
@@ -277,8 +276,8 @@ public class ScheduleGenerator {
 				periodIndex++;
 				// The following code only makes calculations on periodStartXxx while the periodEndXxx is only copied and used to check if we terminate
 				// Determine period start
-				if(isUseEndOfMonth && maturity.getDayOfMonth() == maturity.dayOfMonth().getMaximumValue()) {
-					periodStartDateUnadjusted = maturity
+				if(isUseEndOfMonth && maturityDate.getDayOfMonth() == maturityDate.dayOfMonth().getMaximumValue()) {
+					periodStartDateUnadjusted = maturityDate
 							.plusDays(1)
 							.minusDays(periodLengthDays*periodIndex)
 							.minusWeeks(periodLengthWeeks*periodIndex)
@@ -286,7 +285,7 @@ public class ScheduleGenerator {
 							.minusDays(1);
 				}
 				else {
-					periodStartDateUnadjusted = maturity
+					periodStartDateUnadjusted = maturityDate
 							.minusDays(periodLengthDays*periodIndex)
 							.minusWeeks(periodLengthWeeks*periodIndex)
 							.minusMonths(periodLengthMonth*periodIndex);
@@ -323,7 +322,7 @@ public class ScheduleGenerator {
 	}
 
 	/**
-	 * Schedule generation from meta data.
+	 * Schedule generation for given {referenceDate,startDate,maturityDate}.
 	 * 
 	 * Generates a schedule based on some meta data.
 	 * <ul>
@@ -335,8 +334,8 @@ public class ScheduleGenerator {
 	 * t = 0 corresponds to the reference date.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param startDate The start date of the first period.
-	 * @param maturity The end date of the first period.
+	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
+	 * @param maturityDate The end date of the first period (this may/should be an unadjusted date).
 	 * @param frequency The frequency.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
@@ -349,7 +348,7 @@ public class ScheduleGenerator {
 	public static ScheduleInterface createScheduleFromConventions(
 			LocalDate referenceDate,
 			LocalDate startDate,
-			LocalDate maturity,
+			LocalDate maturityDate,
 			Frequency frequency,
 			DaycountConvention daycountConvention,
 			ShortPeriodConvention shortPeriodConvention,
@@ -359,11 +358,11 @@ public class ScheduleGenerator {
 			int	paymentOffsetDays
 			)
 	{
-		return createScheduleFromConventions(referenceDate, startDate, maturity, frequency, daycountConvention, shortPeriodConvention, dateRollConvention, businessdayCalendar, fixingOffsetDays, paymentOffsetDays, false /* use end of month rule */);
+		return createScheduleFromConventions(referenceDate, startDate, maturityDate, frequency, daycountConvention, shortPeriodConvention, dateRollConvention, businessdayCalendar, fixingOffsetDays, paymentOffsetDays, false);
 	}
 
 	/**
-	 * Schedule generation from meta data.
+	 * Schedule generation for given {referenceDate,startDate,maturityDate}.
 	 * 
 	 * Generates a schedule based on some meta data.
 	 * <ul>
@@ -375,11 +374,11 @@ public class ScheduleGenerator {
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
-	 * @param frequency The frequency.
-	 * @param daycountConvention The daycount convention.
-	 * @param shortPeriodConvention If short period exists, have it first or last.
-	 * @param dateRollConvention Adjustment to be applied to the all dates.
+	 * @param maturityDate The end date of the first period (this may/should be an unadjusted date).
+	 * @param frequency The frequency (as String).
+	 * @param daycountConvention The daycount convention (as String).
+	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
+	 * @param dateRollConvention Adjustment to be applied to the all dates (as String).
 	 * @param businessdayCalendar Businessday calendar (holiday calendar) to be used for date roll adjustment.
 	 * @param fixingOffsetDays Number of business days to be added to period start to get the fixing date.
 	 * @param paymentOffsetDays Number of business days to be added to period end to get the payment date.
@@ -413,7 +412,7 @@ public class ScheduleGenerator {
 	}
 
 	/**
-	 * Schedule generation from meta data (method using Date instead of LocalDate for backward compatibility).
+	 * Schedule generation for given {referenceDate,startDate,maturityDate}. Method using Date instead of LocalDate for backward compatibility.
 	 * 
 	 * Generates a schedule based on some meta data.
 	 * <ul>
@@ -426,10 +425,10 @@ public class ScheduleGenerator {
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
 	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
-	 * @param frequency The frequency.
-	 * @param daycountConvention The daycount convention.
-	 * @param shortPeriodConvention If short period exists, have it first or last.
-	 * @param dateRollConvention Adjustment to be applied to the all dates.
+	 * @param frequency The frequency (as String).
+	 * @param daycountConvention The daycount convention (as String).
+	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
+	 * @param dateRollConvention Adjustment to be applied to the all dates (as String).
 	 * @param businessdayCalendar Businessday calendar (holiday calendar) to be used for date roll adjustment.
 	 * @param fixingOffsetDays Number of business days to be added to period start to get the fixing date.
 	 * @param paymentOffsetDays Number of business days to be added to period end to get the payment date.
@@ -448,35 +447,23 @@ public class ScheduleGenerator {
 			int	paymentOffsetDays
 			)
 	{
-		return createScheduleFromConventions(
-				new LocalDate(referenceDate),
-				new LocalDate(startDate),
-				new LocalDate(maturityDate),
-				frequency,
-				daycountConvention,
-				shortPeriodConvention,
-				dateRollConvention,
-				businessdayCalendar,
-				fixingOffsetDays,
-				paymentOffsetDays
-				);
+		return createScheduleFromConventions(new LocalDate(referenceDate), new LocalDate(startDate), new LocalDate(maturityDate), frequency, daycountConvention, shortPeriodConvention, dateRollConvention, businessdayCalendar, fixingOffsetDays, paymentOffsetDays);
 	}
 
 	/**
-	 * Simple schedule generation.
+	 * Simple schedule generation where startDate and maturityDate are calculated based on tradeDate, spotOffsetDays, startOffsetString and maturityString.
 	 * 
-	 * Generates a schedule based on some meta data. The schedule generation
-	 * considers short periods. Date rolling is ignored.
+	 * The schedule generation considers short periods. Date rolling is ignored.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param tradeDate Base date for the schedule generation (used to build spot date).
 	 * @param spotOffsetDays Number of business days to be added to the trade date to obtain the spot date.
-	 * @param startOffset The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturity The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param frequency The frequency.
-	 * @param daycountConvention The day count convention.
-	 * @param shortPeriodConvention If short period exists, have it first or last.
-	 * @param dateRollConvention Adjustment to be applied to the all dates.
+	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param frequency The frequency (as String).
+	 * @param daycountConvention The daycount convention (as String).
+	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
+	 * @param dateRollConvention Adjustment to be applied to the all dates (as String).
 	 * @param businessdayCalendar Business day calendar (holiday calendar) to be used for date roll adjustment.
 	 * @param fixingOffsetDays Number of business days to be added to period start to get the fixing date.
 	 * @param paymentOffsetDays Number of business days to be added to period end to get the payment date.
@@ -486,8 +473,8 @@ public class ScheduleGenerator {
 			LocalDate referenceDate,
 			LocalDate tradeDate,
 			int spotOffsetDays,
-			String startOffset,
-			String maturity,
+			String startOffsetString,
+			String maturityString,
 			String frequency,
 			String daycountConvention,
 			String shortPeriodConvention,
@@ -497,41 +484,26 @@ public class ScheduleGenerator {
 			int	paymentOffsetDays
 			)
 	{
-	
 		LocalDate spotDate = businessdayCalendar.getRolledDate(tradeDate, spotOffsetDays);
-		
-		LocalDate startDate = BusinessdayCalendar.createDateFromDateAndOffsetCode(spotDate, startOffset);
+		LocalDate unadjustedStartDate = businessdayCalendar.createDateFromDateAndOffsetCode(spotDate, startOffsetString);
+		LocalDate unadjustedMaturityDate = businessdayCalendar.createDateFromDateAndOffsetCode(unadjustedStartDate, maturityString);
 	
-		LocalDate maturityDate = BusinessdayCalendar.createDateFromDateAndOffsetCode(startDate, maturity);
-	
-		return createScheduleFromConventions(
-				referenceDate,
-				startDate,
-				maturityDate,
-				Frequency.valueOf(frequency.replace("/", "_").toUpperCase()), 
-				DaycountConvention.getEnum(daycountConvention),
-				ShortPeriodConvention.valueOf(shortPeriodConvention.replace("/", "_").toUpperCase()),
-				DateRollConvention.getEnum(dateRollConvention),
-				businessdayCalendar,
-				fixingOffsetDays,
-				paymentOffsetDays
-				);
+		return createScheduleFromConventions(referenceDate, unadjustedStartDate, unadjustedMaturityDate, frequency, daycountConvention, shortPeriodConvention, dateRollConvention, businessdayCalendar, fixingOffsetDays, paymentOffsetDays);
 	}
 
 	/**
-	 * Simple schedule generation.
+	 * Simple schedule generation where startDate and maturityDate are calculated based on referenceDate, spotOffsetDays, startOffsetString and maturityString.
 	 * 
-	 * Generates a schedule based on some meta data. The schedule generation
-	 * considers short periods. Date rolling is ignored.
+	 * The schedule generation considers short periods. Date rolling is ignored.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param spotOffsetDays Number of business days to be added to the reference date to obtain the spot date.
-	 * @param startOffset The start date as an offset from the spotDate (build from referenceDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturity The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param frequency The frequency.
-	 * @param daycountConvention The day count convention.
-	 * @param shortPeriodConvention If short period exists, have it first or last.
-	 * @param dateRollConvention Adjustment to be applied to the all dates.
+	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param frequency The frequency (as String).
+	 * @param daycountConvention The daycount convention (as String).
+	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
+	 * @param dateRollConvention Adjustment to be applied to the all dates (as String).
 	 * @param businessdayCalendar Business day calendar (holiday calendar) to be used for date roll adjustment.
 	 * @param fixingOffsetDays Number of business days to be added to period start to get the fixing date.
 	 * @param paymentOffsetDays Number of business days to be added to period end to get the payment date.
@@ -541,8 +513,8 @@ public class ScheduleGenerator {
 	public static ScheduleInterface createScheduleFromConventions(
 			LocalDate referenceDate,
 			int spotOffsetDays,
-			String startOffset,
-			String maturity,
+			String startOffsetString,
+			String maturityString,
 			String frequency,
 			String daycountConvention,
 			String shortPeriodConvention,
@@ -553,12 +525,9 @@ public class ScheduleGenerator {
 			boolean isUseEndOfMonth
 			)
 	{
-		
 		LocalDate spotDate = businessdayCalendar.getRolledDate(referenceDate, spotOffsetDays);
-		
-		LocalDate startDate = BusinessdayCalendar.createDateFromDateAndOffsetCode(spotDate, startOffset);
-	
-		LocalDate maturityDate = BusinessdayCalendar.createDateFromDateAndOffsetCode(startDate, maturity);
+		LocalDate startDate = businessdayCalendar.createDateFromDateAndOffsetCode(spotDate, startOffsetString);
+		LocalDate maturityDate = businessdayCalendar.createDateFromDateAndOffsetCode(startDate, maturityString);
 	
 		return createScheduleFromConventions(
 				referenceDate,
@@ -576,19 +545,18 @@ public class ScheduleGenerator {
 	}
 
 	/**
-	 * Simple schedule generation.
+	 * Simple schedule generation where startDate and maturityDate are calculated based on referenceDate, spotOffsetDays, startOffsetString and maturityString.
 	 * 
-	 * Generates a schedule based on some meta data. The schedule generation
-	 * considers short periods. Date rolling is ignored.
+	 * The schedule generation considers short periods. Date rolling is ignored.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param spotOffsetDays Number of business days to be added to the reference date to obtain the spot date.
-	 * @param startOffset The start date as an offset from the spotDate (build from referenceDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturity The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param frequency The frequency.
-	 * @param daycountConvention The day count convention.
-	 * @param shortPeriodConvention If short period exists, have it first or last.
-	 * @param dateRollConvention Adjustment to be applied to the all dates.
+	 * @param spotOffsetDays Number of business days to be added to the trade date to obtain the spot date.
+	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param frequency The frequency (as String).
+	 * @param daycountConvention The daycount convention (as String).
+	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
+	 * @param dateRollConvention Adjustment to be applied to the all dates (as String).
 	 * @param businessdayCalendar Business day calendar (holiday calendar) to be used for date roll adjustment.
 	 * @param fixingOffsetDays Number of business days to be added to period start to get the fixing date.
 	 * @param paymentOffsetDays Number of business days to be added to period end to get the payment date.
@@ -597,8 +565,8 @@ public class ScheduleGenerator {
 	public static ScheduleInterface createScheduleFromConventions(
 			LocalDate referenceDate,
 			int spotOffsetDays,
-			String startOffset,
-			String maturity,
+			String startOffsetString,
+			String maturityString,
 			String frequency,
 			String daycountConvention,
 			String shortPeriodConvention,
@@ -608,22 +576,22 @@ public class ScheduleGenerator {
 			int	paymentOffsetDays
 			)
 	{
-		return createScheduleFromConventions(referenceDate, referenceDate, spotOffsetDays, startOffset, maturity, frequency, daycountConvention, shortPeriodConvention, dateRollConvention, businessdayCalendar, fixingOffsetDays, paymentOffsetDays);
+		// tradeDate=referenceDate
+		return createScheduleFromConventions(referenceDate, referenceDate, spotOffsetDays, startOffsetString, maturityString, frequency, daycountConvention, shortPeriodConvention, dateRollConvention, businessdayCalendar, fixingOffsetDays, paymentOffsetDays);
 	}
 
 	/**
-	 * Simple schedule generation.
+	 * Simple schedule generation where startDate and maturityDate are calculated based on referenceDate, startOffsetString and maturityString.
 	 * 
-	 * Generates a schedule based on some meta data. The schedule generation
-	 * considers short periods. Date rolling is ignored.
+	 * The schedule generation considers short periods. Date rolling is ignored.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param startOffset The start date as an offset from the referenceDate entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturity The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param frequency The frequency.
-	 * @param daycountConvention The day count convention.
-	 * @param shortPeriodConvention If short period exists, have it first or last.
-	 * @param dateRollConvention Adjustment to be applied to the all dates.
+	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param frequency The frequency (as String).
+	 * @param daycountConvention The daycount convention (as String).
+	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
+	 * @param dateRollConvention Adjustment to be applied to the all dates (as String).
 	 * @param businessdayCalendar Business day calendar (holiday calendar) to be used for date roll adjustment.
 	 * @param fixingOffsetDays Number of business days to be added to period start to get the fixing date.
 	 * @param paymentOffsetDays Number of business days to be added to period end to get the payment date.
@@ -631,8 +599,8 @@ public class ScheduleGenerator {
 	 */
 	public static ScheduleInterface createScheduleFromConventions(
 			LocalDate referenceDate,
-			String startOffset,
-			String maturity,
+			String startOffsetString,
+			String maturityString,
 			String frequency,
 			String daycountConvention,
 			String shortPeriodConvention,
@@ -642,22 +610,8 @@ public class ScheduleGenerator {
 			int	paymentOffsetDays
 			)
 	{
-		LocalDate startDate = BusinessdayCalendar.createDateFromDateAndOffsetCode(referenceDate, startOffset);
-	
-		LocalDate maturityDate = BusinessdayCalendar.createDateFromDateAndOffsetCode(startDate, maturity);
-	
-		return createScheduleFromConventions(
-				referenceDate,
-				startDate,
-				maturityDate,
-				Frequency.valueOf(frequency.replace("/", "_").toUpperCase()), 
-				DaycountConvention.getEnum(daycountConvention),
-				ShortPeriodConvention.valueOf(shortPeriodConvention.replace("/", "_").toUpperCase()),
-				DateRollConvention.getEnum(dateRollConvention),
-				businessdayCalendar,
-				fixingOffsetDays,
-				paymentOffsetDays
-				);
+		// spotOffsetDays=0
+		return createScheduleFromConventions(referenceDate, 0, startOffsetString, maturityString, frequency, daycountConvention, shortPeriodConvention, dateRollConvention, businessdayCalendar, fixingOffsetDays, paymentOffsetDays);
 	}
 
 	/**

--- a/src/main/java6/net/finmath/time/ScheduleGenerator.java
+++ b/src/main/java6/net/finmath/time/ScheduleGenerator.java
@@ -127,7 +127,7 @@ public class ScheduleGenerator {
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the first period (this may/should be an unadjusted date).
+	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
 	 * @param frequency The frequency.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
@@ -335,7 +335,7 @@ public class ScheduleGenerator {
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the first period (this may/should be an unadjusted date).
+	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
 	 * @param frequency The frequency.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
@@ -374,7 +374,7 @@ public class ScheduleGenerator {
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the first period (this may/should be an unadjusted date).
+	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
 	 * @param frequency The frequency (as String).
 	 * @param daycountConvention The daycount convention (as String).
 	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
@@ -459,7 +459,7 @@ public class ScheduleGenerator {
 	 * @param tradeDate Base date for the schedule generation (used to build spot date).
 	 * @param spotOffsetDays Number of business days to be added to the trade date to obtain the spot date.
 	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the last period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
 	 * @param frequency The frequency (as String).
 	 * @param daycountConvention The daycount convention (as String).
 	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
@@ -499,7 +499,7 @@ public class ScheduleGenerator {
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param spotOffsetDays Number of business days to be added to the reference date to obtain the spot date.
 	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the last period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
 	 * @param frequency The frequency (as String).
 	 * @param daycountConvention The daycount convention (as String).
 	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
@@ -552,7 +552,7 @@ public class ScheduleGenerator {
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param spotOffsetDays Number of business days to be added to the trade date to obtain the spot date.
 	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the last period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
 	 * @param frequency The frequency (as String).
 	 * @param daycountConvention The daycount convention (as String).
 	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
@@ -587,7 +587,7 @@ public class ScheduleGenerator {
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startOffsetString The start date as an offset from the spotDate (build from tradeDate and spotOffsetDays) entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
-	 * @param maturityString The end date of the first period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
+	 * @param maturityString The end date of the last period entered as a code like 1D, 1W, 1M, 2M, 3M, 1Y, etc.
 	 * @param frequency The frequency (as String).
 	 * @param daycountConvention The daycount convention (as String).
 	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
@@ -621,7 +621,7 @@ public class ScheduleGenerator {
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startDate The start date of the first period.
 	 * @param frequency The frequency.
-	 * @param maturity The end date of the first period.
+	 * @param maturity The end date of the last period.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
 	 * @param dateRollConvention Adjustment to be applied to the all dates.
@@ -668,7 +668,7 @@ public class ScheduleGenerator {
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
 	 * @param startDate The start date of the first period.
 	 * @param frequency The frequency.
-	 * @param maturity The end date of the first period.
+	 * @param maturity The end date of the last period.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
 	 * @return The corresponding schedule

--- a/src/main/java6/net/finmath/time/ScheduleGenerator.java
+++ b/src/main/java6/net/finmath/time/ScheduleGenerator.java
@@ -126,8 +126,8 @@ public class ScheduleGenerator {
 	 * t = 0 corresponds to the reference date.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
+	 * @param startDate The start date of the first period (unadjusted - adjustments take place during schedule generation).
+	 * @param maturityDate The end date of the last period (unadjusted - adjustments take place during schedule generation).
 	 * @param frequency The frequency.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
@@ -334,8 +334,8 @@ public class ScheduleGenerator {
 	 * t = 0 corresponds to the reference date.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
+	 * @param startDate The start date of the first period (unadjusted - adjustments take place during schedule generation).
+	 * @param maturityDate The end date of the last period (unadjusted - adjustments take place during schedule generation).
 	 * @param frequency The frequency.
 	 * @param daycountConvention The daycount convention.
 	 * @param shortPeriodConvention If short period exists, have it first or last.
@@ -373,8 +373,8 @@ public class ScheduleGenerator {
 	 * The reference date is used internally to represent all dates as doubles.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
+	 * @param startDate The start date of the first period (unadjusted - adjustments take place during schedule generation).
+	 * @param maturityDate The end date of the last period (unadjusted - adjustments take place during schedule generation).
 	 * @param frequency The frequency (as String).
 	 * @param daycountConvention The daycount convention (as String).
 	 * @param shortPeriodConvention If short period exists, have it first or last (as String).
@@ -423,8 +423,8 @@ public class ScheduleGenerator {
 	 * The reference date is used internally to represent all dates as doubles.
 	 * 
 	 * @param referenceDate The date which is used in the schedule to internally convert dates to doubles, i.e., the date where t=0.
-	 * @param startDate The start date of the first period (this may/should be an unadjusted date).
-	 * @param maturityDate The end date of the last period (this may/should be an unadjusted date).
+	 * @param startDate The start date of the first period (unadjusted - adjustments take place during schedule generation).
+	 * @param maturityDate The end date of the last period (unadjusted - adjustments take place during schedule generation).
 	 * @param frequency The frequency (as String).
 	 * @param daycountConvention The daycount convention (as String).
 	 * @param shortPeriodConvention If short period exists, have it first or last (as String).

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendar.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendar.java
@@ -70,86 +70,76 @@ public abstract class BusinessdayCalendar implements BusinessdayCalendarInterfac
 		return rolledDate;
 	}
 
-	/**
-	 * Get an adjusted date for a given date and offset code.
-	 * 
-	 * First we create a new date by "adding" an offset to the base date.
-	 * The offset may be given by codes like 1D, 2D, 1W, 2W, 1M, 2M, 3M,
-	 * 1Y, 2Y, etc., where the letters denote the units as follows: D denotes days, W denotes weeks, M denotes month
-	 * Y denotes years.
-	 * 
-	 * Next the result is adjusted according to the given dateRollConvention.
-	 * 
-	 * @param baseDate The start date.
-	 * @param dateOffsetCode String containing date offset codes (like 2D, 1W, 3M, etc.) or combination of them separated by spaces.
-	 * @param dateRollConvention The date roll convention to be used for the adjustment.
-	 * @return The adjusted date applying dateRollConvention to the given date.
+	/* (non-Javadoc)
+	 * @see net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface#getAdjustedDate(LocalDate, String, DateRollConvention)
 	 */
 	public LocalDate getAdjustedDate(LocalDate baseDate, String dateOffsetCode, DateRollConvention dateRollConvention) {
-		return this.getAdjustedDate(createDateFromDateAndOffsetCode(baseDate, dateOffsetCode), dateRollConvention);
+		return getAdjustedDate(createDateFromDateAndOffsetCode(baseDate, dateOffsetCode), dateRollConvention);
 	}
 
-	/**
-	 * Create a new date by "adding" a year fraction to a given base date.
-	 * 
-	 * <p>
-	 * The date offset may be given by codes like 1D, 2D, 1W, 2W, 1M, 2M, 3M,
-	 * 1Y, 2Y, etc., where the letters denote the units as follows: D denotes days, W denotes weeks, M denotes month
-	 * Y denotes years. If the date offset does not carry a letter code at the end, it will
-	 * be interpreted as ACT/365 year fraction.
-	 * </p>
-	 * 
-	 * <p>
-	 * The function may be used to ease the creation of maturities in spreadsheets.
-	 * </p>
-	 * 
-	 * @param baseDate The start date.
-	 * @param dateOffsetCode String containing date offset codes (like 2D, 1W, 3M, etc.) or combination of them separated by spaces.
-	 * @return A date corresponding the date adding the offset to the start date.
+	/* (non-Javadoc)
+	 * @see net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface#createDateFromDateAndOffsetCode(LocalDate, createDateFromDateAndOffsetCode)
 	 */
-	public static LocalDate createDateFromDateAndOffsetCode(LocalDate baseDate, String dateOffsetCode) {
+	public LocalDate createDateFromDateAndOffsetCode(LocalDate baseDate, String dateOffsetCode) {
 		dateOffsetCode = dateOffsetCode.trim();
 
 		StringTokenizer tokenizer = new StringTokenizer(dateOffsetCode);
 		
-		LocalDate maturity = baseDate;
+		LocalDate maturityDate = baseDate;
 		while(tokenizer.hasMoreTokens()) {
 			String maturityCodeSingle = tokenizer.nextToken();
-
-			char unitChar = maturityCodeSingle.toLowerCase().charAt(maturityCodeSingle.length()-1);
-
+			// get unit identifier (usually last char but may be last two chars)
+			char unitChar;
+			int maturityValue;
+			if(maturityCodeSingle.toLowerCase().substring(maturityCodeSingle.length()-2).equals("bd")) {
+				unitChar = 'b';
+				maturityValue = Integer.valueOf(maturityCodeSingle.substring(0, maturityCodeSingle.length()-2));
+			} else {
+				unitChar = maturityCodeSingle.toLowerCase().charAt(maturityCodeSingle.length()-1);
+				maturityValue = Integer.valueOf(maturityCodeSingle.substring(0, maturityCodeSingle.length()-1));
+			}
+			
+			// note that switch(string) would only work for java >=6
 			switch(unitChar) {
 			case 'd':
 			{
-				int maturityValue = Integer.valueOf(maturityCodeSingle.substring(0, maturityCodeSingle.length()-1));
-				maturity = maturity.plusDays(maturityValue);
+				maturityDate = maturityDate.plusDays(maturityValue);
+				break;
+			}
+			case 'b':
+			{
+				maturityDate = getRolledDate(maturityDate,maturityValue);
 				break;
 			}
 			case 'w':
 			{
-				int maturityValue = Integer.valueOf(maturityCodeSingle.substring(0, maturityCodeSingle.length()-1));
-				maturity = maturity.plusWeeks(maturityValue);
+				maturityDate = maturityDate.plusWeeks(maturityValue);
 				break;
 			}
 			case 'm':
 			{
-				int maturityValue = Integer.valueOf(maturityCodeSingle.substring(0, maturityCodeSingle.length()-1));
-				maturity = maturity.plusMonths(maturityValue);
+				maturityDate = maturityDate.plusMonths(maturityValue);
 				break;
 			}
 			case 'y':
 			{
-				int maturityValue = Integer.valueOf(maturityCodeSingle.substring(0, maturityCodeSingle.length()-1));
-				maturity = maturity.plusYears(maturityValue);
+				maturityDate = maturityDate.plusYears(maturityValue);
 				break;
 			}
 			default:
+				throw new IllegalArgumentException("Cannot handle dateOffsetCode '" + dateOffsetCode + "'.");
+				/**
 				// Try to parse a double as ACT/365
 				double maturityValue	= Double.valueOf(maturityCodeSingle);
 				maturity = maturity.plusDays((int)Math.round(maturityValue * 365));
+				*/
 			}
 		}
 
-		return maturity;
+		return maturityDate;
+	}
+	
+	public String toString() {
+		return "BusinessdayCalendar";
 	}
 }

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarAny.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarAny.java
@@ -29,4 +29,7 @@ public class BusinessdayCalendarAny extends BusinessdayCalendar {
 		return true;
 	}
 
+	public String toString() {
+		return "BusinessdayCalendarAny";
+	}
 }

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
@@ -87,4 +87,8 @@ public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalen
 
 	    return (easterSundayMonth == month) && (easterSundayDay == day);
 	}
+	
+	public String toString() {
+		return "BusinessdayCalendarExcludingTARGETHolidays";
+	}
 }

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingWeekends.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingWeekends.java
@@ -42,4 +42,8 @@ public class BusinessdayCalendarExcludingWeekends extends BusinessdayCalendar {
 			&& date.getDayOfWeek() != DateTimeConstants.SATURDAY 
 			&& date.getDayOfWeek() != DateTimeConstants.SUNDAY;  
 	}
+	
+	public String toString() {
+		return "BusinessdayCalendarExcludingWeekends";
+	}
 }

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
@@ -83,4 +83,26 @@ public interface BusinessdayCalendarInterface {
 	 * @return A date of a business day such that the number of business days between this one (including) and the start date (excluding) is businessDays.
 	 */
 	public LocalDate getRolledDate(LocalDate baseDate, int businessDays);
+	
+	/**
+	 * Create a new date by "adding" a year fraction to a given base date.
+	 * 
+	 * <p>
+	 * The date offset may be given by codes like 1D, 2D, 1W, 2W, 1M, 2M, 3M,
+	 * 1Y, 2Y, etc., where the letters denote the units as follows: D denotes days, W denotes weeks, M denotes month
+	 * Y denotes years. If the date offset does not carry a letter code at the end, it will
+	 * be interpreted as ACT/365 year fraction.
+	 * </p>
+	 * 
+	 * <p>
+	 * The function may be used to ease the creation of maturities in spreadsheets.
+	 * </p>
+	 * 
+	 * @param baseDate The start date.
+	 * @param dateOffsetCode String containing date offset codes (like 2D, 1W, 3M, etc.) or combination of them separated by spaces.
+	 * @return A date corresponding the date adding the offset to the start date.
+	 */
+	LocalDate createDateFromDateAndOffsetCode(LocalDate baseDate, String dateOffsetCode);
+	
+	public String toString();
 }

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
@@ -115,9 +115,21 @@ public interface BusinessdayCalendarInterface {
 	 * 
 	 * <p>
 	 * The date offset may be given by codes like 1D, 2D, 1W, 2W, 1M, 2M, 3M,
-	 * 1Y, 2Y, etc., where the letters denote the units as follows: D denotes days, W denotes weeks, M denotes month
-	 * Y denotes years. If the date offset does not carry a letter code at the end, it will
+	 * 1Y, 2Y, etc., where the letters denote the units of the corresponding offset.
+	 * 
+	 * If the date offset does not carry a letter code at the end, it will
 	 * be interpreted as ACT/365 year fraction.
+	 * </p>
+	 * 
+	 * <p>
+	 * Date offsets can be given as (mapping to the corresponding <code>DateOffsetUnit</code>):
+	 * <dl>
+	 * 	<dt>days</dt>				<dd>"D", "DAYS"</dd>
+	 * 	<dt>business days</dt>		<dd>"B", "BD", "BUSINESS_DAYS"</dd>
+	 * 	<dt>weeks</dt>				<dd>"W", "WEEKS"</dd>
+	 * 	<dt>months</dt>				<dd>"M", "MONTHS"</dd>
+	 * 	<dt>years</dt>				<dd>"Y", "YEARS"</dd>
+	 * </dl>
 	 * </p>
 	 * 
 	 * <p>

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
@@ -12,7 +12,7 @@ import org.joda.time.LocalDate;
  * @author Christian Fries
  */
 public interface BusinessdayCalendarInterface {
-	
+
 	public enum DateOffsetUnit {
 		DAYS,
 		BUSINESS_DAYS,
@@ -27,18 +27,18 @@ public interface BusinessdayCalendarInterface {
 		 * @return The date roll convention enum.
 		 */
 		public static DateOffsetUnit getEnum(String string) {
-	        if(string == null) throw new IllegalArgumentException();
-	        if(string.equalsIgnoreCase("d"))	return DAYS;
-	        if(string.equalsIgnoreCase("b"))	return BUSINESS_DAYS;
-	        if(string.equalsIgnoreCase("bd"))	return BUSINESS_DAYS;
-	        if(string.equalsIgnoreCase("w"))	return WEEKS;
-	        if(string.equalsIgnoreCase("m"))	return MONTHS;
-	        if(string.equalsIgnoreCase("y"))	return YEARS;
+			if(string == null) throw new IllegalArgumentException();
+			if(string.equalsIgnoreCase("d"))	return DAYS;
+			if(string.equalsIgnoreCase("b"))	return BUSINESS_DAYS;
+			if(string.equalsIgnoreCase("bd"))	return BUSINESS_DAYS;
+			if(string.equalsIgnoreCase("w"))	return WEEKS;
+			if(string.equalsIgnoreCase("m"))	return MONTHS;
+			if(string.equalsIgnoreCase("y"))	return YEARS;
 
-	        return DateOffsetUnit.valueOf(string.toUpperCase());
+			return DateOffsetUnit.valueOf(string.toUpperCase());
 		}
 	}
-	
+
 	public enum DateRollConvention {
 		UNADJUSTED,
 		FOLLOWING,
@@ -53,18 +53,18 @@ public interface BusinessdayCalendarInterface {
 		 * @return The date roll convention enum.
 		 */
 		public static DateRollConvention getEnum(String string) {
-	        if(string == null) throw new IllegalArgumentException();
-	        if(string.equalsIgnoreCase("actual"))		return UNADJUSTED;
-	        if(string.equalsIgnoreCase("modfollow"))	return MODIFIED_FOLLOWING;
-	        if(string.equalsIgnoreCase("modpreced"))	return MODIFIED_PRECEDING;
-	        if(string.equalsIgnoreCase("follow"))		return 	FOLLOWING;
-	        if(string.equalsIgnoreCase("preced"))		return 	PRECEDING;
+			if(string == null) throw new IllegalArgumentException();
+			if(string.equalsIgnoreCase("actual"))		return UNADJUSTED;
+			if(string.equalsIgnoreCase("modfollow"))	return MODIFIED_FOLLOWING;
+			if(string.equalsIgnoreCase("modpreced"))	return MODIFIED_PRECEDING;
+			if(string.equalsIgnoreCase("follow"))		return 	FOLLOWING;
+			if(string.equalsIgnoreCase("preced"))		return 	PRECEDING;
 
-	        return DateRollConvention.valueOf(string.toUpperCase());
-	    }
+			return DateRollConvention.valueOf(string.toUpperCase());
+		}
 	}
 
-	
+
 	/**
 	 * Test if a given date is a businessday.
 	 * 
@@ -72,7 +72,7 @@ public interface BusinessdayCalendarInterface {
 	 * @return True, if the given date is a businessday, otherwise false.
 	 */
 	boolean isBusinessday(LocalDate date);
-	
+
 	/**
 	 * Get an adjusted date for a given date.
 	 * 
@@ -109,7 +109,7 @@ public interface BusinessdayCalendarInterface {
 	 * @return A date of a business day such that the number of business days between this one (including) and the start date (excluding) is businessDays.
 	 */
 	public LocalDate getRolledDate(LocalDate baseDate, int businessDays);
-	
+
 	/**
 	 * Create a new date by "adding" a year fraction to a given base date.
 	 * 
@@ -141,6 +141,6 @@ public interface BusinessdayCalendarInterface {
 	 * @return A date corresponding the date adding the offset to the start date.
 	 */
 	LocalDate createDateFromDateAndOffsetCode(LocalDate baseDate, String dateOffsetCode);
-	
+
 	public String toString();
 }

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarInterface.java
@@ -13,6 +13,32 @@ import org.joda.time.LocalDate;
  */
 public interface BusinessdayCalendarInterface {
 	
+	public enum DateOffsetUnit {
+		DAYS,
+		BUSINESS_DAYS,
+		WEEKS,
+		MONTHS,
+		YEARS;
+
+		/**
+		 * Get the date offset unit enum for a string (using common synonyms like "d", "b", "bd", "w").
+		 * 
+		 * @param string The date roll convention name.
+		 * @return The date roll convention enum.
+		 */
+		public static DateOffsetUnit getEnum(String string) {
+	        if(string == null) throw new IllegalArgumentException();
+	        if(string.equalsIgnoreCase("d"))	return DAYS;
+	        if(string.equalsIgnoreCase("b"))	return BUSINESS_DAYS;
+	        if(string.equalsIgnoreCase("bd"))	return BUSINESS_DAYS;
+	        if(string.equalsIgnoreCase("w"))	return WEEKS;
+	        if(string.equalsIgnoreCase("m"))	return MONTHS;
+	        if(string.equalsIgnoreCase("y"))	return YEARS;
+
+	        return DateOffsetUnit.valueOf(string.toUpperCase());
+		}
+	}
+	
 	public enum DateRollConvention {
 		UNADJUSTED,
 		FOLLOWING,

--- a/src/test/java6/net/finmath/marketdata/model/volatilities/CapletVolatilitiesParametricCalibrationTest.java
+++ b/src/test/java6/net/finmath/marketdata/model/volatilities/CapletVolatilitiesParametricCalibrationTest.java
@@ -34,14 +34,12 @@ import net.finmath.time.ScheduleGenerator;
 import net.finmath.time.ScheduleGenerator.DaycountConvention;
 import net.finmath.time.ScheduleGenerator.Frequency;
 import net.finmath.time.ScheduleGenerator.ShortPeriodConvention;
-import net.finmath.time.businessdaycalendar.BusinessdayCalendar;
+import net.finmath.time.businessdaycalendar.BusinessdayCalendarAny;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarExcludingTARGETHolidays;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarExcludingWeekends;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface;
 import net.finmath.time.businessdaycalendar.BusinessdayCalendarInterface.DateRollConvention;
-import net.finmath.time.daycount.DayCountConventionInterface;
 import net.finmath.time.daycount.DayCountConvention_ACT_360;
-import net.finmath.time.daycount.DayCountConvention_ACT_365;
 
 /**
  * This class makes some basic tests related to the setup, use and calibration of discount curves and forward curve.
@@ -157,9 +155,10 @@ public class CapletVolatilitiesParametricCalibrationTest {
 		ArrayList<Double>					marketTargetValues = new ArrayList<Double>();
 		LocalDate referenceDate = new LocalDate(2014, DateTimeConstants.JULY,  15);
 		DaycountConvention capDayCountConvention = DaycountConvention.ACT_360;
+		BusinessdayCalendarInterface dummyBusDayCalendar = new BusinessdayCalendarAny();
 		for(int i=0; i<maturities.length; i++) {
 			LocalDate	tradeDate		= referenceDate;
-			LocalDate	maturityDate	= BusinessdayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
+			LocalDate	maturityDate	= dummyBusDayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
 			double		volatility		= volatilities[i];
 			Cap cap = new Cap(
 					ScheduleGenerator.createScheduleFromConventions(referenceDate, tradeDate, maturityDate, Frequency.SEMIANNUAL, capDayCountConvention, ShortPeriodConvention.FIRST, DateRollConvention.FOLLOWING, new BusinessdayCalendarExcludingWeekends(), 0, 0),
@@ -188,7 +187,7 @@ public class CapletVolatilitiesParametricCalibrationTest {
 		ArrayList<Double>					calibrationTargetValues = new ArrayList<Double>();
 		for(int i=0; i<maturities.length; i++) {
 			LocalDate	tradeDate		= referenceDate;
-			LocalDate	maturityDate	= BusinessdayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
+			LocalDate	maturityDate	= dummyBusDayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
 			double		volatility		= volatilities[i];
 			Cap cap = new Cap(
 					ScheduleGenerator.createScheduleFromConventions(referenceDate, tradeDate, maturityDate, Frequency.SEMIANNUAL, capDayCountConvention, ShortPeriodConvention.FIRST, DateRollConvention.FOLLOWING, new BusinessdayCalendarExcludingWeekends(), 0, 0),

--- a/src/test/java6/net/finmath/marketdata/model/volatilities/CapletVolatilitiesParametricCalibrationTest.java
+++ b/src/test/java6/net/finmath/marketdata/model/volatilities/CapletVolatilitiesParametricCalibrationTest.java
@@ -155,10 +155,10 @@ public class CapletVolatilitiesParametricCalibrationTest {
 		ArrayList<Double>					marketTargetValues = new ArrayList<Double>();
 		LocalDate referenceDate = new LocalDate(2014, DateTimeConstants.JULY,  15);
 		DaycountConvention capDayCountConvention = DaycountConvention.ACT_360;
-		BusinessdayCalendarInterface dummyBusDayCalendar = new BusinessdayCalendarAny();
+		BusinessdayCalendarInterface businessdayCalendar = new BusinessdayCalendarExcludingTARGETHolidays(new BusinessdayCalendarExcludingWeekends());
 		for(int i=0; i<maturities.length; i++) {
 			LocalDate	tradeDate		= referenceDate;
-			LocalDate	maturityDate	= dummyBusDayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
+			LocalDate	maturityDate	= businessdayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
 			double		volatility		= volatilities[i];
 			Cap cap = new Cap(
 					ScheduleGenerator.createScheduleFromConventions(referenceDate, tradeDate, maturityDate, Frequency.SEMIANNUAL, capDayCountConvention, ShortPeriodConvention.FIRST, DateRollConvention.FOLLOWING, new BusinessdayCalendarExcludingWeekends(), 0, 0),
@@ -187,7 +187,7 @@ public class CapletVolatilitiesParametricCalibrationTest {
 		ArrayList<Double>					calibrationTargetValues = new ArrayList<Double>();
 		for(int i=0; i<maturities.length; i++) {
 			LocalDate	tradeDate		= referenceDate;
-			LocalDate	maturityDate	= dummyBusDayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
+			LocalDate	maturityDate	= businessdayCalendar.createDateFromDateAndOffsetCode(referenceDate, maturities[i]);
 			double		volatility		= volatilities[i];
 			Cap cap = new Cap(
 					ScheduleGenerator.createScheduleFromConventions(referenceDate, tradeDate, maturityDate, Frequency.SEMIANNUAL, capDayCountConvention, ShortPeriodConvention.FIRST, DateRollConvention.FOLLOWING, new BusinessdayCalendarExcludingWeekends(), 0, 0),

--- a/src/test/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarTest.java
+++ b/src/test/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarTest.java
@@ -1,0 +1,75 @@
+package net.finmath.time.businessdaycalendar;
+
+import org.joda.time.LocalDate;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Provides a few simple tests for Business Day Calendars.
+ * 
+ * @author Christian Fries
+ */
+public class BusinessdayCalendarTest {
+
+
+	/**
+	 * Simple tests for date offset codes (1D, 1W, etc.).
+	 */
+	@Test
+	public void testCreateDateFromDateAndOffsetCode() {
+		BusinessdayCalendarInterface bdCalendarAny = new BusinessdayCalendarAny();
+
+		LocalDate baseDate = new LocalDate(2016, 4, 27);
+
+		// Test ACT/365 offsets
+		for(float offset : new float[] { 1/365.0f, 2/365.0f, 0.25f, 0.5f, 1.0f }) {
+			String offsetCode = Double.toString(offset);
+			LocalDate targetDate = bdCalendarAny.createDateFromDateAndOffsetCode(baseDate, offsetCode);
+			Assert.assertTrue(baseDate.plusDays(Math.round(offset*365)).isEqual(targetDate));
+		}
+
+		// Test days
+		for(int days : new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 100 }) {
+			String offsetCode = Integer.toString(days) + "D";
+			LocalDate targetDate = bdCalendarAny.createDateFromDateAndOffsetCode(baseDate, offsetCode);
+			Assert.assertTrue(baseDate.plusDays(days).isEqual(targetDate));
+		}
+
+		// Test weeks
+		for(int weeks : new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 100 }) {
+			String offsetCode = Integer.toString(weeks) + "W";
+			LocalDate targetDate = bdCalendarAny.createDateFromDateAndOffsetCode(baseDate, offsetCode);
+			Assert.assertTrue(baseDate.plusWeeks(weeks).isEqual(targetDate));
+		}
+
+
+		// Test month
+		for(int months : new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 100 }) {
+			String offsetCode = Integer.toString(months) + "M";
+			LocalDate targetDate = bdCalendarAny.createDateFromDateAndOffsetCode(baseDate, offsetCode);
+			Assert.assertTrue(baseDate.plusMonths(months).isEqual(targetDate));
+		}
+
+		// Test years
+		for(int years : new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 100 }) {
+			String offsetCode = Integer.toString(years) + "Y";
+			LocalDate targetDate = bdCalendarAny.createDateFromDateAndOffsetCode(baseDate, offsetCode);
+			Assert.assertTrue(baseDate.plusYears(years).isEqual(targetDate));
+		}
+
+		// Test business days for BusinessdayCalendarAny
+		for(int days : new int[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 100 }) {
+			String offsetCode = Integer.toString(days) + "BD";
+			LocalDate targetDate = bdCalendarAny.createDateFromDateAndOffsetCode(baseDate, offsetCode);
+			Assert.assertTrue(baseDate.plusDays(days).isEqual(targetDate));
+		}
+
+		// Test business days for BusinessdayCalendarExcludingWeekends
+		BusinessdayCalendarInterface bdCalendarWeekends = new BusinessdayCalendarExcludingWeekends();
+		for(int days : new int[] { 1, 5, 10, 20, 100 }) {
+			String offsetCode = Integer.toString(days) + "BD";
+			LocalDate targetDate = bdCalendarWeekends.createDateFromDateAndOffsetCode(baseDate, offsetCode);
+			Assert.assertTrue(baseDate.plusDays((int) Math.round(days / 5.0 * 7.0)).isEqual(targetDate));
+		}
+	}
+}


### PR DESCRIPTION
- BusinessdayCalendar::createDateFromDateAndOffsetCode(): Make method
non-static to enable business day rolling; add business day rolling
(indicated by 'b' or 'bd')
- BusinessdayCalendar::createDateFromDateAndOffsetCode(): throw
exception if unit char is of unknown type instead of trying to parse as
Act/365
- BusinessdayCalendar: moved some documentation to
BusinessdayCalendarInterface
- BusinessdayCalendar...: Added simple toString() methods
- ScheduleGenerator: Reduced some code duplication in
createScheduleFromConventions() method by letting them better call each
other