### PR TITLE
AnalyticalModel: No curve wrapping in getDiscountCurve() method

### DIFF
--- a/src/main/java6/net/finmath/marketdata/model/AnalyticModel.java
+++ b/src/main/java6/net/finmath/marketdata/model/AnalyticModel.java
@@ -116,25 +116,20 @@ public class AnalyticModel implements AnalyticModelInterface, Cloneable {
 	@Override
 	public DiscountCurveInterface getDiscountCurve(String discountCurveName) {
 		DiscountCurveInterface discountCurve = null;
-		CurveInterface curveForDiscountingCurve			= getCurve(discountCurveName);
-		if(DiscountCurveInterface.class.isInstance(curveForDiscountingCurve)) {
-			discountCurve	= (DiscountCurveInterface)curveForDiscountingCurve;
-		}
-		else if(ForwardCurveInterface.class.isInstance(curveForDiscountingCurve)) {
-			// Check if the discount curve is a forward curve
-			ForwardCurveInterface	forwardCurveForDiscounting	= (ForwardCurveInterface) curveForDiscountingCurve;
-			discountCurve = new DiscountCurveFromForwardCurve(forwardCurveForDiscounting.getName());
-		}
+		CurveInterface curve = getCurve(discountCurveName);
+		if(DiscountCurveInterface.class.isInstance(curve))
+			discountCurve = (DiscountCurveInterface)curve;
+
 		return discountCurve;
 	}
 
 	@Override
 	public ForwardCurveInterface getForwardCurve(String forwardCurveName) {
 		ForwardCurveInterface forwardCurve = null;
-		CurveInterface curveForForwards			= getCurve(forwardCurveName);
-		if(ForwardCurveInterface.class.isInstance(curveForForwards)) {
-			forwardCurve	= (ForwardCurveInterface)curveForForwards;
-		}
+		CurveInterface curve = getCurve(forwardCurveName);
+		if(ForwardCurveInterface.class.isInstance(curve))
+			forwardCurve = (ForwardCurveInterface)curve;
+
 		return forwardCurve;
 	}
 

--- a/src/main/java6/net/finmath/marketdata/model/AnalyticModelInterface.java
+++ b/src/main/java6/net/finmath/marketdata/model/AnalyticModelInterface.java
@@ -61,8 +61,14 @@ public interface AnalyticModelInterface extends ModelInterface, Cloneable {
 	@Deprecated
 	void setCurve(CurveInterface curve);
 
+	/**
+	 * @return dicountCurve corresponding to discountCurveName or null if no discountCurve with this name exists in the model
+	 */
 	DiscountCurveInterface getDiscountCurve(String discountCurveName);
 
+	/**
+	 * @return forwardCurve corresponding to forwardCurveName or null if no forwardCurve with this name exists in the model
+	 */
 	ForwardCurveInterface getForwardCurve(String forwardCurveName);
 	
 	HazardCurveInterface getHazardCurve(String hazardCurveName);


### PR DESCRIPTION
### What is this PR for?
- Do not use
DiscountCurveFromForwardCurve-wrapper in getDiscountCurve() if given
curveName corresponds to forwardCurve. This is analogous to the
behaviour of getForwardCurve()
- added documentation for getDiscountCurve() and getForwardCurve() in
the interface

### What type of PR is it?
Improvement 

### Questions:
Is it problematic for others user to have this more strict behaviour of AnalyticalModel::getDiscountCurve()?
