### PR TITLE
Stricter behaviour of CalibratedCurves::createForwardCurve()

### DIFF
--- a/src/main/java6/net/finmath/marketdata/calibration/CalibratedCurves.java
+++ b/src/main/java6/net/finmath/marketdata/calibration/CalibratedCurves.java
@@ -709,7 +709,8 @@ public class CalibratedCurves {
 	}
 
 	/**
-	 * Get a forward curve from the model, if not existing create a forward curve.
+	 * Get a forwardCurve from the model (by name) or throw exception of no such forwardCurve exists in the model. 
+	 * Note that if given curve corresponds to a discountCurve then a ForwardCurveFromDiscountCurve is created from the discountCurve.
 	 * 
 	 * @param swapTenorDefinition The swap tenor associated with the forward curve.
 	 * @param forwardCurveName The name of the forward curve to create.

--- a/src/main/java6/net/finmath/marketdata/calibration/CalibratedCurves.java
+++ b/src/main/java6/net/finmath/marketdata/calibration/CalibratedCurves.java
@@ -716,6 +716,9 @@ public class CalibratedCurves {
 	 * @return The forward curve associated with the given name.
 	 */
 	private String createForwardCurve(ScheduleInterface swapTenorDefinition, String forwardCurveName) {
+		if(forwardCurveName == null || forwardCurveName.isEmpty()) 
+			return null;
+		
 		// Check if the curves exists, throw exception otherwise
 		CurveInterface	curve = model.getCurve(forwardCurveName); // note that this may be a discount curve
 		if(curve == null) 


### PR DESCRIPTION
### What is this PR for?
- CalibratedCurves::createForwardCurve(): do not create fallback curve
if no curve with the given name exists in the model
- CalibratedCurves::createForwardCurve(): Only wrap discountCurve if it
has not already been wrapped
- remove no superfluous flag isUseForwardCurve

### What type of PR is it?
Feature