### PR TITLE
Slightly different weekend treatment in TARGET calendar && removed 31.12. from TARGET calendar 

### DIFF
--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
@@ -41,19 +41,15 @@ public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalen
 		int day = date.getDayOfMonth();
 		int month = date.getMonthValue();
 
-		LocalDate datePlus2 = date.plusDays(2);
-		LocalDate dateBefore = date.minusDays(1);
-
 		BusinessdayCalendarInterface weekdayCalendar = new BusinessdayCalendarExcludingWeekends();
 		return	weekdayCalendar.isBusinessday(date)
 				&& (baseCalendar == null || baseCalendar.isBusinessday(date))
-				&&	!(day ==  1 && month ==  1)		// date is New Year
-				&&	!(day == 25 && month == 12)		// date is Christmas
-				&&	!(day == 26 && month == 12)		// date is Boxing Day
-				&&	!(day == 31 && month == 12)
-				&&	!(day ==  1 && month ==  5)		// date is Labour Day
-				&&	!isEasterSunday(datePlus2)		// date is Good Friday
-				&&	!isEasterSunday(dateBefore)		// date is Easter Monday
+				&&	!(day ==  1 && month ==  1)			// date is New Year
+				&&	!isEasterSunday(date.plusDays(2))	// date is Good Friday
+				&&	!isEasterSunday(date.minusDays(1))	// date is Easter Monday
+				&&	!(day ==  1 && month ==  5)			// date is Labour Day
+				&&	!(day == 25 && month == 12)			// date is Christmas
+				&&	!(day == 26 && month == 12)			// date is Boxing Day
 				;
 	}
 

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
@@ -17,6 +17,7 @@ import org.threeten.bp.LocalDate;
 public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalendar {
 
 	private BusinessdayCalendarInterface baseCalendar;
+	private final BusinessdayCalendarInterface weekdayCalendar = new BusinessdayCalendarExcludingWeekends();
 	
 	/**
 	 * Create business day calendar.
@@ -41,7 +42,6 @@ public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalen
 		int day = date.getDayOfMonth();
 		int month = date.getMonthValue();
 
-		BusinessdayCalendarInterface weekdayCalendar = new BusinessdayCalendarExcludingWeekends();
 		return	weekdayCalendar.isBusinessday(date)
 				&& (baseCalendar == null || baseCalendar.isBusinessday(date))
 				&&	!(day ==  1 && month ==  1)			// date is New Year

--- a/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
+++ b/src/main/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarExcludingTARGETHolidays.java
@@ -22,7 +22,6 @@ public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalen
 	 * Create business day calendar.
 	 */
 	public BusinessdayCalendarExcludingTARGETHolidays() {
-		this.baseCalendar = new BusinessdayCalendarExcludingWeekends();
 	}
 
 	/**
@@ -31,7 +30,7 @@ public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalen
 	 * @param baseCalendar Calendar of business days.
 	 */
 	public BusinessdayCalendarExcludingTARGETHolidays(BusinessdayCalendarInterface baseCalendar) {
-		this.baseCalendar = new BusinessdayCalendarExcludingWeekends(baseCalendar);
+		this.baseCalendar = baseCalendar;
 	}
 	
 	/* (non-Javadoc)
@@ -45,7 +44,9 @@ public class BusinessdayCalendarExcludingTARGETHolidays extends BusinessdayCalen
 		LocalDate datePlus2 = date.plusDays(2);
 		LocalDate dateBefore = date.minusDays(1);
 
-		return	(baseCalendar == null || baseCalendar.isBusinessday(date))
+		BusinessdayCalendarInterface weekdayCalendar = new BusinessdayCalendarExcludingWeekends();
+		return	weekdayCalendar.isBusinessday(date)
+				&& (baseCalendar == null || baseCalendar.isBusinessday(date))
 				&&	!(day ==  1 && month ==  1)		// date is New Year
 				&&	!(day == 25 && month == 12)		// date is Christmas
 				&&	!(day == 26 && month == 12)		// date is Boxing Day

--- a/src/test/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarTest.java
+++ b/src/test/java6/net/finmath/time/businessdaycalendar/BusinessdayCalendarTest.java
@@ -73,4 +73,36 @@ public class BusinessdayCalendarTest {
 			Assert.assertTrue(baseDate.plusDays((int) Math.round(days / 5.0 * 7.0)).isEqual(targetDate));
 		}
 	}
+	
+	/**
+	 * Simple tests for TARGET calendar.
+	 */
+	@Test
+	public void testTargetHolidays() {
+		BusinessdayCalendarInterface targetCalendar = new BusinessdayCalendarExcludingTARGETHolidays();
+		
+		LocalDate weekend = LocalDate.of(2017, 6, 10);
+		Assert.assertTrue(!targetCalendar.isBusinessday(weekend));
+		
+		LocalDate weekendAndHoliday = LocalDate.of(2017, 1, 1);
+		Assert.assertTrue(!targetCalendar.isBusinessday(weekendAndHoliday));
+		
+		LocalDate newYear = LocalDate.of(2018, 1, 1);
+		Assert.assertTrue(!targetCalendar.isBusinessday(newYear));
+		
+		LocalDate goodFriday = LocalDate.of(2017, 4, 14);
+		Assert.assertTrue(!targetCalendar.isBusinessday(goodFriday));
+		
+		LocalDate easterMonday = LocalDate.of(2017, 4, 17);
+		Assert.assertTrue(!targetCalendar.isBusinessday(easterMonday));
+		
+		LocalDate labourDay = LocalDate.of(2017, 5, 1);
+		Assert.assertTrue(!targetCalendar.isBusinessday(labourDay));
+		
+		LocalDate christmasDay = LocalDate.of(2017, 12, 25);
+		Assert.assertTrue(!targetCalendar.isBusinessday(christmasDay));
+		
+		LocalDate boxingDay = LocalDate.of(2017, 12, 26);
+		Assert.assertTrue(!targetCalendar.isBusinessday(boxingDay));
+	}
 }


### PR DESCRIPTION
## What is this PR for?
Slightly different weekend treatment in TARGET calendar:
- Assume you have a NEWYORK calendar that also adds WEEKDAY automatically as base calendar. Now you want to built union of TARGET and NEWYORK calendars by building a NEWYORK calendar with TARGET as base. Then you have NEWYORK with base WEEKDAY with base TARGET with base WEEKDAY. That is a bit ugly
- This is just a cosmetic change. Weekends will still be non-bussinesdays in the TARGET calendar

Removed 31.12. from TARGET calendar

### What type of PR is it?
Improvement/Feature