### PR TITLE
Add generation of javadoc & source .jar files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,42 +194,63 @@
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.10.4</version>
-				<configuration>
-					<doctitle>${project.name} (${project.version}) documentation</doctitle>
-					<stylesheetfile>stylesheet.css</stylesheetfile>
-					<docfilessubdirs>true</docfilessubdirs>
-					<header>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<doctitle>${project.name} (${project.version}) documentation</doctitle>
+							<stylesheetfile>stylesheet.css</stylesheetfile>
+							<docfilessubdirs>true</docfilessubdirs>
+							<header>
 			   			<![CDATA[
 						<span class="logo-white">finMath</span><span class="logo-red"> lib</span> documentation
 						<script type="text/javascript" src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-AMS-MML_HTMLorMML'></script>
 			   			]]>
-					</header>
-					<footer>
+							</header>
+							<footer>
 			   			<![CDATA[
 						<i>Copyright &copy; 2017 Christian&nbsp;P.&nbsp;Fries.</i>
 			   			]]>
-					</footer>
-					<tags>
-						<tag>
-							<name>TODO</name>
-							<placement>a</placement>
-							<head>To dos:</head>
-						</tag>
-						<tag>
-							<name>date</name>
-							<placement>a</placement>
-							<head>Date:</head>
-						</tag>
-					</tags>
-					<links>
-						<link>http://commons.apache.org/proper/commons-lang/javadocs/api-release</link>
-						<link>http://commons.apache.org/proper/commons-math/javadocs/api-3.3</link>
-					</links>
-					<detectLinks>true</detectLinks>
-					<additionalparam>--allow-script-in-comments</additionalparam>
-				</configuration>
+							</footer>
+							<tags>
+								<tag>
+									<name>TODO</name>
+									<placement>a</placement>
+									<head>To dos:</head>
+								</tag>
+								<tag>
+									<name>date</name>
+									<placement>a</placement>
+									<head>Date:</head>
+								</tag>
+							</tags>
+							<links>
+								<link>http://commons.apache.org/proper/commons-lang/javadocs/api-release</link>
+								<link>http://commons.apache.org/proper/commons-math/javadocs/api-3.3</link>
+							</links>
+							<detectLinks>true</detectLinks>
+							<additionalparam>--allow-script-in-comments</additionalparam>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### What is this PR for?
This PR extends the pom.xml to automatically generate source and API .jar files.

The changes follow the guidance issued here:
https://maven.apache.org/plugin-developers/cookbook/attach-source-javadoc-artifacts.html

### What type of PR is it?
Improvement

### Todos
N/A

### What is the related issue?
https://github.com/finmath/finmath-lib/issues/49

Note: this PR doesn't address the suggested Travis CI change.  But, it does produce the .jar files that could/would be included in Release.

### How should this be tested?
Inspect build folder on completion.

### Screenshots


### Questions:

**Does the licenses files need update?**

No
 
**Are there breaking changes for older versions?**

No

**Does the change require additional documentation?**

No 

