### PR TITLE
Fix bugs in TimeDiscretization and enhance TimeDiscretizationInterface

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
 	<groupId>net.finmath</groupId>
 	<artifactId>finmath-lib</artifactId>
-	<version>3.2.11</version>
+	<version>3.2.12-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>finmath lib</name>
@@ -656,7 +656,7 @@
 		<url>https://github.com/finmath/finmath-lib</url>
 		<connection>scm:git:https://github.com/finmath/finmath-lib.git</connection>
 		<developerConnection>scm:git:https://github.com/finmath/finmath-lib.git</developerConnection>
-		<tag>finmath-lib-3.2.11</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 	<ciManagement>

--- a/src/main/java/net/finmath/time/TimeDiscretization.java
+++ b/src/main/java/net/finmath/time/TimeDiscretization.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.*;
 
 /**
  * This class represents a set of discrete points in time.
@@ -29,71 +30,99 @@ import java.util.Set;
 public class TimeDiscretization implements Serializable, TimeDiscretizationInterface {
 
 	private static final long serialVersionUID = 6880668325019167781L;
-	private static final double	timeTickSizeDefault = Double.parseDouble(System.getProperty("net.finmath.functions.TimeDiscretization.timeTickSize", new Double(1.0 / (365.0 * 24.0)).toString()));
+    private static final double timeTickSizeDefault = Double.parseDouble(System.getProperty("net.finmath.functions.TimeDiscretization.timeTickSize", Double.toString(1.0 / (365.0 * 24.0))));
 
 	private final double[]	timeDiscretization;
-	private final double	timeTickSize = timeTickSizeDefault;
+    private double timeTickSize;
 
 	public enum ShortPeriodLocation {
 		SHORT_PERIOD_AT_START,
 		SHORT_PERIOD_AT_END
 	}
 
+    /**
+     * Constructs a time discretization using the given tick size.
+     *
+     * @param times    A non closed and not necessarily sorted stream containing the time points.
+     * @param tickSize A non-negative double representing the smallest time span distinguishable.
+     */
+    public TimeDiscretization(DoubleStream times, double tickSize) {
+        this.timeTickSize = tickSize;
+        this.timeDiscretization = times.map(this::roundToTimeTickSize).distinct().sorted().toArray();
+    }
+
+    /**
+     * Constructs a time discretization from a (non closed and not necessarily sorted) stream of doubles.
+     *
+     * @param times A double stream of time points for the time discretization.
+     */
+    public TimeDiscretization(DoubleStream times) {
+        this(times, timeTickSizeDefault);
+    }
+
+    /**
+     * CConstructs a time discretization using the given tick size.
+     *
+     * @param times    A non closed and not necessarily sorted stream containing the time points.
+     * @param tickSize A non-negative double representing the smallest time span distinguishable.
+     */
+    public TimeDiscretization(Stream<Double> times, double tickSize) {
+        this(times.mapToDouble(d -> d), tickSize);
+    }
+
+    /**
+     * Constructs a time discretization from a (non closed and not necessarily sorted) stream of boxed doubles.
+     *
+     * @param times A double stream of time points for the time discretization.
+     */
+    public TimeDiscretization(Stream<Double> times) {
+        this(times.mapToDouble(d -> d));
+    }
+
+    /**
+     * Constructs a time discretization using the given tick size.
+     * The iteration of the iterable does not have to happen in order.
+     */
+    public TimeDiscretization(Iterable<Double> times, double tickSize) {
+        this(StreamSupport.stream(times.spliterator(), false), tickSize);
+    }
+
+    /**
+     * Constructs a time discretization from an iterable of doubles.
+     * The iteration does not have to happen in order.
+     */
+    public TimeDiscretization(Iterable<Double> times) {
+        this(StreamSupport.stream(times.spliterator(), false));
+    }
+
 	/**
 	 * Constructs a time discretization from a given set of doubles.
 	 * The given array does not need to be sorted.
 	 * 
 	 * @param times Given array or arguments list of discretization points.
-	 */
-	public TimeDiscretization(double... times) {
-		super();
-		this.timeDiscretization = times.clone();
-		java.util.Arrays.sort(this.timeDiscretization);
+     */
+    public TimeDiscretization(double... times) {
+        this(Arrays.stream(times));
 	}
 
 	/**
 	 * Constructs a time discretization from a given set of Doubles.
-	 * The given array does not need to be sorted.
-	 * 
-	 * @param times Given array or arguments list of discretization points.
-	 */
-	public TimeDiscretization(Double[] times) {
-		super();
-		this.timeDiscretization = new double[times.length];
-		for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
-			this.timeDiscretization[timeIndex] = roundToTimeTickSize(times[timeIndex]);
-		}
-		java.util.Arrays.sort(this.timeDiscretization);
-	}
+     * The given array does not need to be sorted.
+     *
+     * @param times Given boxed array of discretization points.
+     */
+    public TimeDiscretization(Double[] times) {
+        this(Arrays.stream(times));
+    }
 
-	/**
-	 * Constructs a time discretization from a given ArrayList of Doubles.
-	 * The given list does not need to be sorted.
-	 * 
-	 * @param timeDiscretization Given ArrayList of discretization points
-	 */
-	public TimeDiscretization(ArrayList<Double> timeDiscretization) {
-		super();
-		this.timeDiscretization = new double[timeDiscretization.size()];
-		for(int timeIndex=0; timeIndex<timeDiscretization.size(); timeIndex++) {
-			this.timeDiscretization[timeIndex] = roundToTimeTickSize(timeDiscretization.get(timeIndex));
-		}
-		java.util.Arrays.sort(this.timeDiscretization);
-	}
-
-	/**
-	 * Constructs a time discretization from a given Set of Doubles.
-	 * 
-	 * @param times Given Set of discretization points
-	 */
-	public TimeDiscretization(Set<Double> times) {
-		super();
-		this.timeDiscretization = new double[times.size()];
-		Iterator<Double> time = times.iterator();
-		for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
-			this.timeDiscretization[timeIndex] = roundToTimeTickSize(time.next());
-		}
-		java.util.Arrays.sort(this.timeDiscretization);
+    /**
+     * Constructs a time discretization using the given tick size.
+     * The given array does not need to be sorted.
+     *
+     * @param times Given boxed array of discretization points.
+     */
+    public TimeDiscretization(Double[] times, double tickSize) {
+        this(Arrays.stream(times), tickSize);
 	}
 
 	/**
@@ -105,11 +134,7 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 	 * @param deltaT Time step size.
 	 */
 	public TimeDiscretization(double initial, int numberOfTimeSteps, double deltaT) {
-		super();
-		timeDiscretization = new double[numberOfTimeSteps+1];
-		for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
-			timeDiscretization[timeIndex] = roundToTimeTickSize(initial + timeIndex * deltaT);
-		}
+        this(IntStream.range(0, numberOfTimeSteps + 1).mapToDouble(n -> initial + n * deltaT));
 	}
 
 	/**
@@ -120,29 +145,19 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 	 * @param deltaT Time step size.
 	 * @param shortPeriodLocation Placement of the stub period.
 	 */
-	public TimeDiscretization(double initial, double last, double deltaT, ShortPeriodLocation shortPeriodLocation) {
-		super();
-		int numberOfTimeSteps = (int)((last-initial)/ deltaT + 0.5);
+    public TimeDiscretization(double initial, double last, double deltaT, ShortPeriodLocation shortPeriodLocation) {
+        this(getEquidistantStreamWithStub(initial, last, deltaT, shortPeriodLocation));
+    }
 
-		// Adjust for short period, if any
-		if(roundToTimeTickSize(initial + numberOfTimeSteps * deltaT) < roundToTimeTickSize(last)) {
-			numberOfTimeSteps++;
-		}
+    private static DoubleStream getEquidistantStreamWithStub(double initial, double last, double deltaT, ShortPeriodLocation shortPeriodLocation) {
+        int numberOfTimeStepsPlusOne = (int) Math.ceil((last - initial) / deltaT) + 1;
 
-		timeDiscretization = new double[numberOfTimeSteps+1];
-		if(shortPeriodLocation == ShortPeriodLocation.SHORT_PERIOD_AT_END) {
-			for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
-				timeDiscretization[timeIndex] = roundToTimeTickSize(initial + timeIndex * deltaT);
-			}
-			timeDiscretization[timeDiscretization.length-1] = last;
-		}
-		else {
-			for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
-				timeDiscretization[timeIndex] = roundToTimeTickSize(last - (numberOfTimeSteps-timeIndex) * deltaT);
-			}
-			timeDiscretization[0] = initial;
-		}
-	}
+        if (shortPeriodLocation == ShortPeriodLocation.SHORT_PERIOD_AT_END) {
+            return IntStream.range(0, numberOfTimeStepsPlusOne).mapToDouble(n -> Math.min(last, initial + n * deltaT));
+        }
+
+        return IntStream.range(0, numberOfTimeStepsPlusOne).mapToDouble(n -> Math.max(initial, last - n * deltaT));
+    }
 
 	@Override
 	public int getNumberOfTimes() {
@@ -162,12 +177,11 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 	@Override
 	public double getTimeStep(int timeIndex) {
 		return timeDiscretization[timeIndex+1]-timeDiscretization[timeIndex];
-	}
+    }
 
-	@Override
-	public int getTimeIndex(double time) {
-		int index = java.util.Arrays.binarySearch(timeDiscretization,roundToTimeTickSize(time));
-		return index;
+    @Override
+    public int getTimeIndex(double time) {
+        return Arrays.binarySearch(timeDiscretization, roundToTimeTickSize(time));
 	}
 
 	@Override
@@ -204,15 +218,39 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 	}
 
 	@Override
-	public TimeDiscretizationInterface getTimeShiftedTimeDiscretization(double timeShift) {
-		double[] newTimeDiscretization = new double[timeDiscretization.length];
+    public TimeDiscretizationInterface getTimeShiftedTimeDiscretization(double timeShift) {
+        double[] newTimeDiscretization = new double[timeDiscretization.length];
 
-		for(int timeIndex=0; timeIndex<timeDiscretization.length; timeIndex++) {
-			newTimeDiscretization[timeIndex] = roundToTimeTickSize(timeDiscretization[timeIndex]+timeShift);
-		}
+        for (int timeIndex = 0; timeIndex < timeDiscretization.length; timeIndex++) {
+            newTimeDiscretization[timeIndex] = roundToTimeTickSize(timeDiscretization[timeIndex] + timeShift);
+        }
 
-		return new TimeDiscretization(newTimeDiscretization);
-	}
+        return new TimeDiscretization(newTimeDiscretization);
+    }
+
+    /**
+     * @param that Another time discretization containing points to add to the time discretization.
+     * @return A new time discretization containing both the time points of this and the other discretization.
+     */
+    @Override
+    public TimeDiscretizationInterface union(TimeDiscretizationInterface that) {
+        return new TimeDiscretization(
+                Stream.concat(Arrays.stream(timeDiscretization).boxed(), Arrays.stream(that.getAsDoubleArray()).boxed()),
+                Math.max(timeTickSize, that.getTickSize()));
+    }
+
+    @Override
+    public TimeDiscretizationInterface intersect(TimeDiscretizationInterface that) {
+        Set<Double> intersectionSet = Arrays.stream(timeDiscretization).boxed().collect(Collectors.toSet());
+        intersectionSet.retainAll(that.getAsArrayList());
+
+        return new TimeDiscretization(intersectionSet, Math.max(timeTickSize, that.getTickSize()));
+    }
+
+    @Override
+    public double getTickSize() {
+        return timeTickSize;
+    }
 
 	@Override
 	public Iterator<Double> iterator() {

--- a/src/main/java/net/finmath/time/TimeDiscretization.java
+++ b/src/main/java/net/finmath/time/TimeDiscretization.java
@@ -10,7 +10,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.stream.*;
+import java.util.stream.Collectors;
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * This class represents a set of discrete points in time.
@@ -30,99 +34,99 @@ import java.util.stream.*;
 public class TimeDiscretization implements Serializable, TimeDiscretizationInterface {
 
 	private static final long serialVersionUID = 6880668325019167781L;
-    private static final double timeTickSizeDefault = Double.parseDouble(System.getProperty("net.finmath.functions.TimeDiscretization.timeTickSize", Double.toString(1.0 / (365.0 * 24.0))));
+	private static final double timeTickSizeDefault = Double.parseDouble(System.getProperty("net.finmath.functions.TimeDiscretization.timeTickSize", Double.toString(1.0 / (365.0 * 24.0))));
 
 	private final double[]	timeDiscretization;
-    private double timeTickSize;
+	private double timeTickSize;
 
 	public enum ShortPeriodLocation {
 		SHORT_PERIOD_AT_START,
 		SHORT_PERIOD_AT_END
 	}
 
-    /**
-     * Constructs a time discretization using the given tick size.
-     *
-     * @param times    A non closed and not necessarily sorted stream containing the time points.
-     * @param tickSize A non-negative double representing the smallest time span distinguishable.
-     */
-    public TimeDiscretization(DoubleStream times, double tickSize) {
-        this.timeTickSize = tickSize;
-        this.timeDiscretization = times.map(this::roundToTimeTickSize).distinct().sorted().toArray();
-    }
+	/**
+	 * Constructs a time discretization using the given tick size.
+	 *
+	 * @param times    A non closed and not necessarily sorted stream containing the time points.
+	 * @param tickSize A non-negative double representing the smallest time span distinguishable.
+	 */
+	public TimeDiscretization(DoubleStream times, double tickSize) {
+		this.timeTickSize = tickSize;
+		this.timeDiscretization = times.map(this::roundToTimeTickSize).distinct().sorted().toArray();
+	}
 
-    /**
-     * Constructs a time discretization from a (non closed and not necessarily sorted) stream of doubles.
-     *
-     * @param times A double stream of time points for the time discretization.
-     */
-    public TimeDiscretization(DoubleStream times) {
-        this(times, timeTickSizeDefault);
-    }
+	/**
+	 * Constructs a time discretization from a (non closed and not necessarily sorted) stream of doubles.
+	 *
+	 * @param times A double stream of time points for the time discretization.
+	 */
+	public TimeDiscretization(DoubleStream times) {
+		this(times, timeTickSizeDefault);
+	}
 
-    /**
-     * CConstructs a time discretization using the given tick size.
-     *
-     * @param times    A non closed and not necessarily sorted stream containing the time points.
-     * @param tickSize A non-negative double representing the smallest time span distinguishable.
-     */
-    public TimeDiscretization(Stream<Double> times, double tickSize) {
-        this(times.mapToDouble(d -> d), tickSize);
-    }
+	/**
+	 * Constructs a time discretization using the given tick size.
+	 *
+	 * @param times    A non closed and not necessarily sorted stream containing the time points.
+	 * @param tickSize A non-negative double representing the smallest time span distinguishable.
+	 */
+	public TimeDiscretization(Stream<Double> times, double tickSize) {
+		this(times.mapToDouble(d -> d), tickSize);
+	}
 
-    /**
-     * Constructs a time discretization from a (non closed and not necessarily sorted) stream of boxed doubles.
-     *
-     * @param times A double stream of time points for the time discretization.
-     */
-    public TimeDiscretization(Stream<Double> times) {
-        this(times.mapToDouble(d -> d));
-    }
+	/**
+	 * Constructs a time discretization from a (non closed and not necessarily sorted) stream of boxed doubles.
+	 *
+	 * @param times A double stream of time points for the time discretization.
+	 */
+	public TimeDiscretization(Stream<Double> times) {
+		this(times.mapToDouble(d -> d));
+	}
 
-    /**
-     * Constructs a time discretization using the given tick size.
-     * The iteration of the iterable does not have to happen in order.
-     */
-    public TimeDiscretization(Iterable<Double> times, double tickSize) {
-        this(StreamSupport.stream(times.spliterator(), false), tickSize);
-    }
+	/**
+	 * Constructs a time discretization using the given tick size.
+	 * The iteration of the iterable does not have to happen in order.
+	 */
+	public TimeDiscretization(Iterable<Double> times, double tickSize) {
+		this(StreamSupport.stream(times.spliterator(), false), tickSize);
+	}
 
-    /**
-     * Constructs a time discretization from an iterable of doubles.
-     * The iteration does not have to happen in order.
-     */
-    public TimeDiscretization(Iterable<Double> times) {
-        this(StreamSupport.stream(times.spliterator(), false));
-    }
+	/**
+	 * Constructs a time discretization from an iterable of doubles.
+	 * The iteration does not have to happen in order.
+	 */
+	public TimeDiscretization(Iterable<Double> times) {
+		this(StreamSupport.stream(times.spliterator(), false));
+	}
 
 	/**
 	 * Constructs a time discretization from a given set of doubles.
 	 * The given array does not need to be sorted.
-	 * 
+	 *
 	 * @param times Given array or arguments list of discretization points.
-     */
-    public TimeDiscretization(double... times) {
-        this(Arrays.stream(times));
+	 */
+	public TimeDiscretization(double... times) {
+		this(Arrays.stream(times));
 	}
 
 	/**
 	 * Constructs a time discretization from a given set of Doubles.
-     * The given array does not need to be sorted.
-     *
-     * @param times Given boxed array of discretization points.
-     */
-    public TimeDiscretization(Double[] times) {
-        this(Arrays.stream(times));
-    }
+	 * The given array does not need to be sorted.
+	 *
+	 * @param times Given boxed array of discretization points.
+	 */
+	public TimeDiscretization(Double[] times) {
+		this(Arrays.stream(times));
+	}
 
-    /**
-     * Constructs a time discretization using the given tick size.
-     * The given array does not need to be sorted.
-     *
-     * @param times Given boxed array of discretization points.
-     */
-    public TimeDiscretization(Double[] times, double tickSize) {
-        this(Arrays.stream(times), tickSize);
+	/**
+	 * Constructs a time discretization using the given tick size.
+	 * The given array does not need to be sorted.
+	 *
+	 * @param times Given boxed array of discretization points.
+	 */
+	public TimeDiscretization(Double[] times, double tickSize) {
+		this(Arrays.stream(times), tickSize);
 	}
 
 	/**
@@ -134,7 +138,7 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 	 * @param deltaT Time step size.
 	 */
 	public TimeDiscretization(double initial, int numberOfTimeSteps, double deltaT) {
-        this(IntStream.range(0, numberOfTimeSteps + 1).mapToDouble(n -> initial + n * deltaT));
+		this(IntStream.range(0, numberOfTimeSteps + 1).mapToDouble(n -> initial + n * deltaT));
 	}
 
 	/**
@@ -145,19 +149,19 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 	 * @param deltaT Time step size.
 	 * @param shortPeriodLocation Placement of the stub period.
 	 */
-    public TimeDiscretization(double initial, double last, double deltaT, ShortPeriodLocation shortPeriodLocation) {
-        this(getEquidistantStreamWithStub(initial, last, deltaT, shortPeriodLocation));
-    }
+	public TimeDiscretization(double initial, double last, double deltaT, ShortPeriodLocation shortPeriodLocation) {
+		this(getEquidistantStreamWithStub(initial, last, deltaT, shortPeriodLocation));
+	}
 
-    private static DoubleStream getEquidistantStreamWithStub(double initial, double last, double deltaT, ShortPeriodLocation shortPeriodLocation) {
-        int numberOfTimeStepsPlusOne = (int) Math.ceil((last - initial) / deltaT) + 1;
+	private static DoubleStream getEquidistantStreamWithStub(double initial, double last, double deltaT, ShortPeriodLocation shortPeriodLocation) {
+		int numberOfTimeStepsPlusOne = (int) Math.ceil((last - initial) / deltaT) + 1;
 
-        if (shortPeriodLocation == ShortPeriodLocation.SHORT_PERIOD_AT_END) {
-            return IntStream.range(0, numberOfTimeStepsPlusOne).mapToDouble(n -> Math.min(last, initial + n * deltaT));
-        }
+		if (shortPeriodLocation == ShortPeriodLocation.SHORT_PERIOD_AT_END) {
+			return IntStream.range(0, numberOfTimeStepsPlusOne).mapToDouble(n -> Math.min(last, initial + n * deltaT));
+		}
 
-        return IntStream.range(0, numberOfTimeStepsPlusOne).mapToDouble(n -> Math.max(initial, last - n * deltaT));
-    }
+		return IntStream.range(0, numberOfTimeStepsPlusOne).mapToDouble(n -> Math.max(initial, last - n * deltaT));
+	}
 
 	@Override
 	public int getNumberOfTimes() {
@@ -176,12 +180,12 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 
 	@Override
 	public double getTimeStep(int timeIndex) {
-		return timeDiscretization[timeIndex+1]-timeDiscretization[timeIndex];
-    }
+		return timeDiscretization[timeIndex + 1] - timeDiscretization[timeIndex];
+	}
 
-    @Override
-    public int getTimeIndex(double time) {
-        return Arrays.binarySearch(timeDiscretization, roundToTimeTickSize(time));
+	@Override
+	public int getTimeIndex(double time) {
+		return Arrays.binarySearch(timeDiscretization, roundToTimeTickSize(time));
 	}
 
 	@Override
@@ -218,39 +222,39 @@ public class TimeDiscretization implements Serializable, TimeDiscretizationInter
 	}
 
 	@Override
-    public TimeDiscretizationInterface getTimeShiftedTimeDiscretization(double timeShift) {
-        double[] newTimeDiscretization = new double[timeDiscretization.length];
+	public TimeDiscretizationInterface getTimeShiftedTimeDiscretization(double timeShift) {
+		double[] newTimeDiscretization = new double[timeDiscretization.length];
 
-        for (int timeIndex = 0; timeIndex < timeDiscretization.length; timeIndex++) {
-            newTimeDiscretization[timeIndex] = roundToTimeTickSize(timeDiscretization[timeIndex] + timeShift);
-        }
+		for (int timeIndex = 0; timeIndex < timeDiscretization.length; timeIndex++) {
+			newTimeDiscretization[timeIndex] = roundToTimeTickSize(timeDiscretization[timeIndex] + timeShift);
+		}
 
-        return new TimeDiscretization(newTimeDiscretization);
-    }
+		return new TimeDiscretization(newTimeDiscretization);
+	}
 
-    /**
-     * @param that Another time discretization containing points to add to the time discretization.
-     * @return A new time discretization containing both the time points of this and the other discretization.
-     */
-    @Override
-    public TimeDiscretizationInterface union(TimeDiscretizationInterface that) {
-        return new TimeDiscretization(
-                Stream.concat(Arrays.stream(timeDiscretization).boxed(), Arrays.stream(that.getAsDoubleArray()).boxed()),
-                Math.max(timeTickSize, that.getTickSize()));
-    }
+	/**
+	 * @param that Another time discretization containing points to add to the time discretization.
+	 * @return A new time discretization containing both the time points of this and the other discretization.
+	 */
+	@Override
+	public TimeDiscretizationInterface union(TimeDiscretizationInterface that) {
+		return new TimeDiscretization(
+				Stream.concat(Arrays.stream(timeDiscretization).boxed(), Arrays.stream(that.getAsDoubleArray()).boxed()),
+				Math.min(timeTickSize, that.getTickSize()));
+	}
 
-    @Override
-    public TimeDiscretizationInterface intersect(TimeDiscretizationInterface that) {
-        Set<Double> intersectionSet = Arrays.stream(timeDiscretization).boxed().collect(Collectors.toSet());
-        intersectionSet.retainAll(that.getAsArrayList());
+	@Override
+	public TimeDiscretizationInterface intersect(TimeDiscretizationInterface that) {
+		Set<Double> intersectionSet = Arrays.stream(timeDiscretization).boxed().collect(Collectors.toSet());
+		intersectionSet.retainAll(that.getAsArrayList());
 
-        return new TimeDiscretization(intersectionSet, Math.max(timeTickSize, that.getTickSize()));
-    }
+		return new TimeDiscretization(intersectionSet, Math.max(timeTickSize, that.getTickSize()));
+	}
 
-    @Override
-    public double getTickSize() {
-        return timeTickSize;
-    }
+	@Override
+	public double getTickSize() {
+		return timeTickSize;
+	}
 
 	@Override
 	public Iterator<Double> iterator() {

--- a/src/main/java/net/finmath/time/TimeDiscretizationInterface.java
+++ b/src/main/java/net/finmath/time/TimeDiscretizationInterface.java
@@ -92,12 +92,30 @@ public interface TimeDiscretizationInterface extends Iterable<Double> {
 	TimeDiscretizationInterface getTimeShiftedTimeDiscretization(double timeShift);
 
 	/**
+     * Returns the union of this time discretization with another one. This means that the times of the other time discretization will be added.
+     * In case the tick sizes differ the union will have the smaller tick size, i. e. the finer precision.
+     * Note that when the differing tick sizes are not integer multiples of each other time points might get shifted due to rounding;
+     * for example <code>a.intersect(a.union(b))</code> might not be equal to <code>a</code>.
+     *
 	 * @param that Another time discretization containing points to add to the time discretization.
 	 * @return A new time discretization containing both the time points of this and the other discretization.
 	 */
 	TimeDiscretizationInterface union(TimeDiscretizationInterface that);
 
-	TimeDiscretizationInterface intersect(TimeDiscretizationInterface that);
+    /**
+     * Returns the intersection of this time discretization with another one. This means that all times not contained in the other time discretization will be removed.
+     * In case the tick sizes differ the intersection will have the greater tick size, i. e. the coarser precision.
+     * Note that when the differing tick sizes are not integer multiples of each other time points might get shifted due to rounding;
+     * for example <code>a.intersect(a.union(b))</code> might not be equal to <code>a</code>.
+     *
+     * @param that Another time discretization containing points to add to the time discretization.
+     * @return A new time discretization containing both the time points of this and the other discretization.
+     */
+    TimeDiscretizationInterface intersect(TimeDiscretizationInterface that);
 
-	double getTickSize();
+    /**
+     * Returns the smallest time span distinguishable in this time discretization.
+     * @return A non-negative double containing the tick size.
+     */
+    double getTickSize();
 }

--- a/src/main/java/net/finmath/time/TimeDiscretizationInterface.java
+++ b/src/main/java/net/finmath/time/TimeDiscretizationInterface.java
@@ -92,30 +92,30 @@ public interface TimeDiscretizationInterface extends Iterable<Double> {
 	TimeDiscretizationInterface getTimeShiftedTimeDiscretization(double timeShift);
 
 	/**
-     * Returns the union of this time discretization with another one. This means that the times of the other time discretization will be added.
-     * In case the tick sizes differ the union will have the smaller tick size, i. e. the finer precision.
-     * Note that when the differing tick sizes are not integer multiples of each other time points might get shifted due to rounding;
-     * for example <code>a.intersect(a.union(b))</code> might not be equal to <code>a</code>.
-     *
+	 * Returns the union of this time discretization with another one. This means that the times of the other time discretization will be added.
+	 * In case the tick sizes differ the union will have the smaller tick size, i. e. the finer precision.
+	 * Note that when the differing tick sizes are not integer multiples of each other time points might get shifted due to rounding;
+	 * for example <code>a.intersect(a.union(b))</code> might not be equal to <code>a</code>.
+	 *
 	 * @param that Another time discretization containing points to add to the time discretization.
 	 * @return A new time discretization containing both the time points of this and the other discretization.
 	 */
 	TimeDiscretizationInterface union(TimeDiscretizationInterface that);
 
-    /**
-     * Returns the intersection of this time discretization with another one. This means that all times not contained in the other time discretization will be removed.
-     * In case the tick sizes differ the intersection will have the greater tick size, i. e. the coarser precision.
-     * Note that when the differing tick sizes are not integer multiples of each other time points might get shifted due to rounding;
-     * for example <code>a.intersect(a.union(b))</code> might not be equal to <code>a</code>.
-     *
-     * @param that Another time discretization containing points to add to the time discretization.
-     * @return A new time discretization containing both the time points of this and the other discretization.
-     */
-    TimeDiscretizationInterface intersect(TimeDiscretizationInterface that);
+	/**
+	 * Returns the intersection of this time discretization with another one. This means that all times not contained in the other time discretization will be removed.
+	 * In case the tick sizes differ the intersection will have the greater tick size, i. e. the coarser precision.
+	 * Note that when the differing tick sizes are not integer multiples of each other time points might get shifted due to rounding;
+	 * for example <code>a.intersect(a.union(b))</code> might not be equal to <code>a</code>.
+	 *
+	 * @param that Another time discretization containing points to add to the time discretization.
+	 * @return A new time discretization containing both the time points of this and the other discretization.
+	 */
+	TimeDiscretizationInterface intersect(TimeDiscretizationInterface that);
 
-    /**
-     * Returns the smallest time span distinguishable in this time discretization.
-     * @return A non-negative double containing the tick size.
-     */
-    double getTickSize();
+	/**
+	 * Returns the smallest time span distinguishable in this time discretization.
+	 * @return A non-negative double containing the tick size.
+	 */
+	double getTickSize();
 }

--- a/src/main/java/net/finmath/time/TimeDiscretizationInterface.java
+++ b/src/main/java/net/finmath/time/TimeDiscretizationInterface.java
@@ -90,4 +90,14 @@ public interface TimeDiscretizationInterface extends Iterable<Double> {
 	 * @return A new time discretization where all time points have been shifted by the given time shift.
 	 */
 	TimeDiscretizationInterface getTimeShiftedTimeDiscretization(double timeShift);
+
+	/**
+	 * @param that Another time discretization containing points to add to the time discretization.
+	 * @return A new time discretization containing both the time points of this and the other discretization.
+	 */
+	TimeDiscretizationInterface union(TimeDiscretizationInterface that);
+
+	TimeDiscretizationInterface intersect(TimeDiscretizationInterface that);
+
+	double getTickSize();
 }

--- a/src/test/java/net/finmath/time/TimeDiscretizationTest.java
+++ b/src/test/java/net/finmath/time/TimeDiscretizationTest.java
@@ -1,0 +1,232 @@
+package net.finmath.time;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TimeDiscretizationTest {
+
+    private static final double ONE_TENTH_OF_DEFAULT_TICK_SIZE = 0.1 / (365.0 * 24.0);
+
+    private static final double DEFAULT_TICK_SIZE = 1.0 / (365.0 * 24.0);
+
+    private static double getHalfTickMore(double a) {
+        return a + 0.5 / (365.0 * 24.0);
+    }
+
+    @Before
+    public void setUp() {
+        System.setProperty("net.finmath.functions.TimeDiscretization.timeTickSize", Double.toString(DEFAULT_TICK_SIZE));
+    }
+
+    @Test
+    public void constructWithUnboxedArrayAtDefaultTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(a, closeToA);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+    }
+
+    @Test
+    public void constructWithBoxedArrayAtDefaultTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA});
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+    }
+
+    @Test
+    public void constructWithBoxedArrayAtBigTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA}, 1.0);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
+    }
+
+    @Test
+    public void constructWithBoxedArrayAtSmallTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA}, ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
+    }
+
+    @Test
+    public void constructWithSetAtDefaultTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()));
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+    }
+
+    @Test
+    public void constructWithSetAtBigTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()), 1.0);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
+    }
+
+    @Test
+    public void constructWithSetAtSmallTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()), ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
+    }
+
+    @Test
+    public void constructWithArrayListAtDefaultTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())));
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+    }
+
+    @Test
+    public void constructWithArrayListAtBigTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())), 1.0);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
+    }
+
+    @Test
+    public void constructWithArrayListAtSmallTickSize() {
+
+        double a = 4.2;
+        double closeToA = getHalfTickMore(a);
+
+        TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())), ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
+    }
+
+    @Test
+    public void constructWithNumberOfSteps() {
+        TimeDiscretization discretization = new TimeDiscretization(0.0, 5, 0.5);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.5, 1.0, 1.5, 2.0, 2.5})));
+    }
+
+    @Test
+    public void constructWithNumberOfStepsSmallerThanTickSize() {
+        TimeDiscretization discretization = new TimeDiscretization(0.0, 10, ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, DEFAULT_TICK_SIZE})));
+    }
+
+    @Test
+    public void constructWithIntervalShortStubAtEnd() {
+        TimeDiscretization discretization = new TimeDiscretization(0.0, 2.75, 0.5, TimeDiscretization.ShortPeriodLocation.SHORT_PERIOD_AT_END);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 2.75})));
+    }
+
+    @Test
+    public void constructWithIntervalShortStubAtFront() {
+        TimeDiscretization discretization = new TimeDiscretization(0.0, 2.75, 0.5, TimeDiscretization.ShortPeriodLocation.SHORT_PERIOD_AT_START);
+
+        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.25, 0.75, 1.25, 1.75, 2.25, 2.75})));
+    }
+
+    @Test
+    public void testUnionWithNoDuplicates() {
+
+        double[] leftTimes = {1.0, 2.0, 3.0};
+        double[] rightTimes = {0.5, 1.5};
+
+        TimeDiscretizationInterface union = new TimeDiscretization(leftTimes).union(new TimeDiscretization(rightTimes));
+
+        assertThat(union.getAsDoubleArray(), is(equalTo(new double[]{0.5, 1.0, 1.5, 2.0, 3.0})));
+    }
+
+    @Test
+    public void testUnionWithSubTickDuplicates() {
+
+        Double[] leftTimes = {1.0, 2.0, 3.0};
+        Double[] rightTimes = {0.5, 1.5, 1.53};
+
+        TimeDiscretizationInterface union = new TimeDiscretization(leftTimes, 0.1).union(new TimeDiscretization(rightTimes, 0.1));
+
+        assertThat(union.getAsDoubleArray(), is(equalTo(new double[]{0.5, 1.0, 1.5, 2.0, 3.0})));
+    }
+
+    @Test
+    public void testUnionWithDifferentTickSizes() {
+
+        Double[] leftTimes = {7.0, 3.0, 5.0, 3.0};
+        Double[] rightTimes = {5.0, 3.0, 1.0, 8.0, 0.0, 0.0, 8.0};
+
+        TimeDiscretizationInterface union = new TimeDiscretization(leftTimes, 0.1).union(new TimeDiscretization(rightTimes, 1.0));
+
+        assertThat(union.getTickSize(), is(equalTo(1.0)));
+    }
+
+    @Test
+    public void testIntersectionWithNoDuplicates() {
+
+        double[] leftTimes = {1.0, 2.0, 3.0};
+        double[] rightTimes = {0.5, 1.5};
+
+        TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes).intersect(new TimeDiscretization(rightTimes));
+
+        assertThat(intersection.getAsDoubleArray().length, is(equalTo(0)));
+    }
+
+    @Test
+    public void testIntersectionWithSubTickDuplicates() {
+
+        Double[] leftTimes = {1.0, 1.53, 3.0};
+        Double[] rightTimes = {0.5, 1.5};
+
+        TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes, 0.1).intersect(new TimeDiscretization(rightTimes, 0.1));
+
+        assertThat(intersection.getAsDoubleArray(), is(equalTo(new double[]{1.5})));
+    }
+
+    @Test
+    public void testIntersectionWithDifferentTickSizes() {
+
+        Double[] leftTimes = {7.0, 3.0, 5.0, 3.0};
+        Double[] rightTimes = {5.0, 3.0, 1.0, 8.0, 0.0, 0.0, 8.0};
+
+        TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes, 0.1).intersect(new TimeDiscretization(rightTimes, 1.0));
+
+        assertThat(intersection.getTickSize(), is(equalTo(1.0)));
+    }
+}

--- a/src/test/java/net/finmath/time/TimeDiscretizationTest.java
+++ b/src/test/java/net/finmath/time/TimeDiscretizationTest.java
@@ -194,7 +194,7 @@ public class TimeDiscretizationTest {
 
         TimeDiscretizationInterface union = new TimeDiscretization(leftTimes, 0.1).union(new TimeDiscretization(rightTimes, 1.0));
 
-        assertThat(union.getTickSize(), is(equalTo(1.0)));
+        assertThat(union.getTickSize(), is(equalTo(0.1)));
     }
 
     @Test

--- a/src/test/java/net/finmath/time/TimeDiscretizationTest.java
+++ b/src/test/java/net/finmath/time/TimeDiscretizationTest.java
@@ -13,220 +13,220 @@ import static org.junit.Assert.assertThat;
 
 public class TimeDiscretizationTest {
 
-    private static final double ONE_TENTH_OF_DEFAULT_TICK_SIZE = 0.1 / (365.0 * 24.0);
+	private static final double ONE_TENTH_OF_DEFAULT_TICK_SIZE = 0.1 / (365.0 * 24.0);
 
-    private static final double DEFAULT_TICK_SIZE = 1.0 / (365.0 * 24.0);
+	private static final double DEFAULT_TICK_SIZE = 1.0 / (365.0 * 24.0);
 
-    private static double getHalfTickMore(double a) {
-        return a + 0.5 / (365.0 * 24.0);
-    }
+	private static double getHalfTickMore(double a) {
+		return a + 0.5 / (365.0 * 24.0);
+	}
 
-    @Before
-    public void setUp() {
-        System.setProperty("net.finmath.functions.TimeDiscretization.timeTickSize", Double.toString(DEFAULT_TICK_SIZE));
-    }
+	@Before
+	public void setUp() {
+		System.setProperty("net.finmath.functions.TimeDiscretization.timeTickSize", Double.toString(DEFAULT_TICK_SIZE));
+	}
 
-    @Test
-    public void constructWithUnboxedArrayAtDefaultTickSize() {
+	@Test
+	public void constructWithUnboxedArrayAtDefaultTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(a, closeToA);
+		TimeDiscretization discretization = new TimeDiscretization(a, closeToA);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+	}
 
-    @Test
-    public void constructWithBoxedArrayAtDefaultTickSize() {
+	@Test
+	public void constructWithBoxedArrayAtDefaultTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA});
+		TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA});
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+	}
 
-    @Test
-    public void constructWithBoxedArrayAtBigTickSize() {
+	@Test
+	public void constructWithBoxedArrayAtBigTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA}, 1.0);
+		TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA}, 1.0);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
+	}
 
-    @Test
-    public void constructWithBoxedArrayAtSmallTickSize() {
+	@Test
+	public void constructWithBoxedArrayAtSmallTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA}, ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+		TimeDiscretization discretization = new TimeDiscretization(new Double[]{a, closeToA}, ONE_TENTH_OF_DEFAULT_TICK_SIZE);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
+	}
 
-    @Test
-    public void constructWithSetAtDefaultTickSize() {
+	@Test
+	public void constructWithSetAtDefaultTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()));
+		TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()));
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+	}
 
-    @Test
-    public void constructWithSetAtBigTickSize() {
+	@Test
+	public void constructWithSetAtBigTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()), 1.0);
+		TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()), 1.0);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
+	}
 
-    @Test
-    public void constructWithSetAtSmallTickSize() {
+	@Test
+	public void constructWithSetAtSmallTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()), ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+		TimeDiscretization discretization = new TimeDiscretization(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toSet()), ONE_TENTH_OF_DEFAULT_TICK_SIZE);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
+	}
 
-    @Test
-    public void constructWithArrayListAtDefaultTickSize() {
+	@Test
+	public void constructWithArrayListAtDefaultTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())));
+		TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())));
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a})));
+	}
 
-    @Test
-    public void constructWithArrayListAtBigTickSize() {
+	@Test
+	public void constructWithArrayListAtBigTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())), 1.0);
+		TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())), 1.0);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{4.0})));
+	}
 
-    @Test
-    public void constructWithArrayListAtSmallTickSize() {
+	@Test
+	public void constructWithArrayListAtSmallTickSize() {
 
-        double a = 4.2;
-        double closeToA = getHalfTickMore(a);
+		double a = 4.2;
+		double closeToA = getHalfTickMore(a);
 
-        TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())), ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+		TimeDiscretization discretization = new TimeDiscretization(new ArrayList<>(Arrays.stream(new double[]{a, closeToA}).boxed().collect(Collectors.toList())), ONE_TENTH_OF_DEFAULT_TICK_SIZE);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{a, closeToA})));
+	}
 
-    @Test
-    public void constructWithNumberOfSteps() {
-        TimeDiscretization discretization = new TimeDiscretization(0.0, 5, 0.5);
+	@Test
+	public void constructWithNumberOfSteps() {
+		TimeDiscretization discretization = new TimeDiscretization(0.0, 5, 0.5);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.5, 1.0, 1.5, 2.0, 2.5})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.5, 1.0, 1.5, 2.0, 2.5})));
+	}
 
-    @Test
-    public void constructWithNumberOfStepsSmallerThanTickSize() {
-        TimeDiscretization discretization = new TimeDiscretization(0.0, 10, ONE_TENTH_OF_DEFAULT_TICK_SIZE);
+	@Test
+	public void constructWithNumberOfStepsSmallerThanTickSize() {
+		TimeDiscretization discretization = new TimeDiscretization(0.0, 10, ONE_TENTH_OF_DEFAULT_TICK_SIZE);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, DEFAULT_TICK_SIZE})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, DEFAULT_TICK_SIZE})));
+	}
 
-    @Test
-    public void constructWithIntervalShortStubAtEnd() {
-        TimeDiscretization discretization = new TimeDiscretization(0.0, 2.75, 0.5, TimeDiscretization.ShortPeriodLocation.SHORT_PERIOD_AT_END);
+	@Test
+	public void constructWithIntervalShortStubAtEnd() {
+		TimeDiscretization discretization = new TimeDiscretization(0.0, 2.75, 0.5, TimeDiscretization.ShortPeriodLocation.SHORT_PERIOD_AT_END);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 2.75})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.5, 1.0, 1.5, 2.0, 2.5, 2.75})));
+	}
 
-    @Test
-    public void constructWithIntervalShortStubAtFront() {
-        TimeDiscretization discretization = new TimeDiscretization(0.0, 2.75, 0.5, TimeDiscretization.ShortPeriodLocation.SHORT_PERIOD_AT_START);
+	@Test
+	public void constructWithIntervalShortStubAtFront() {
+		TimeDiscretization discretization = new TimeDiscretization(0.0, 2.75, 0.5, TimeDiscretization.ShortPeriodLocation.SHORT_PERIOD_AT_START);
 
-        assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.25, 0.75, 1.25, 1.75, 2.25, 2.75})));
-    }
+		assertThat(discretization.getAsDoubleArray(), is(equalTo(new double[]{0.0, 0.25, 0.75, 1.25, 1.75, 2.25, 2.75})));
+	}
 
-    @Test
-    public void testUnionWithNoDuplicates() {
+	@Test
+	public void testUnionWithNoDuplicates() {
 
-        double[] leftTimes = {1.0, 2.0, 3.0};
-        double[] rightTimes = {0.5, 1.5};
+		double[] leftTimes = {1.0, 2.0, 3.0};
+		double[] rightTimes = {0.5, 1.5};
 
-        TimeDiscretizationInterface union = new TimeDiscretization(leftTimes).union(new TimeDiscretization(rightTimes));
+		TimeDiscretizationInterface union = new TimeDiscretization(leftTimes).union(new TimeDiscretization(rightTimes));
 
-        assertThat(union.getAsDoubleArray(), is(equalTo(new double[]{0.5, 1.0, 1.5, 2.0, 3.0})));
-    }
+		assertThat(union.getAsDoubleArray(), is(equalTo(new double[]{0.5, 1.0, 1.5, 2.0, 3.0})));
+	}
 
-    @Test
-    public void testUnionWithSubTickDuplicates() {
+	@Test
+	public void testUnionWithSubTickDuplicates() {
 
-        Double[] leftTimes = {1.0, 2.0, 3.0};
-        Double[] rightTimes = {0.5, 1.5, 1.53};
+		Double[] leftTimes = {1.0, 2.0, 3.0};
+		Double[] rightTimes = {0.5, 1.5, 1.53};
 
-        TimeDiscretizationInterface union = new TimeDiscretization(leftTimes, 0.1).union(new TimeDiscretization(rightTimes, 0.1));
+		TimeDiscretizationInterface union = new TimeDiscretization(leftTimes, 0.1).union(new TimeDiscretization(rightTimes, 0.1));
 
-        assertThat(union.getAsDoubleArray(), is(equalTo(new double[]{0.5, 1.0, 1.5, 2.0, 3.0})));
-    }
+		assertThat(union.getAsDoubleArray(), is(equalTo(new double[]{0.5, 1.0, 1.5, 2.0, 3.0})));
+	}
 
-    @Test
-    public void testUnionWithDifferentTickSizes() {
+	@Test
+	public void testUnionWithDifferentTickSizes() {
 
-        Double[] leftTimes = {7.0, 3.0, 5.0, 3.0};
-        Double[] rightTimes = {5.0, 3.0, 1.0, 8.0, 0.0, 0.0, 8.0};
+		Double[] leftTimes = {7.0, 3.0, 5.0, 3.0};
+		Double[] rightTimes = {5.0, 3.0, 1.0, 8.0, 0.0, 0.0, 8.0};
 
-        TimeDiscretizationInterface union = new TimeDiscretization(leftTimes, 0.1).union(new TimeDiscretization(rightTimes, 1.0));
+		TimeDiscretizationInterface union = new TimeDiscretization(leftTimes, 0.1).union(new TimeDiscretization(rightTimes, 1.0));
 
-        assertThat(union.getTickSize(), is(equalTo(0.1)));
-    }
+		assertThat(union.getTickSize(), is(equalTo(0.1)));
+	}
 
-    @Test
-    public void testIntersectionWithNoDuplicates() {
+	@Test
+	public void testIntersectionWithNoDuplicates() {
 
-        double[] leftTimes = {1.0, 2.0, 3.0};
-        double[] rightTimes = {0.5, 1.5};
+		double[] leftTimes = {1.0, 2.0, 3.0};
+		double[] rightTimes = {0.5, 1.5};
 
-        TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes).intersect(new TimeDiscretization(rightTimes));
+		TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes).intersect(new TimeDiscretization(rightTimes));
 
-        assertThat(intersection.getAsDoubleArray().length, is(equalTo(0)));
-    }
+		assertThat(intersection.getAsDoubleArray().length, is(equalTo(0)));
+	}
 
-    @Test
-    public void testIntersectionWithSubTickDuplicates() {
+	@Test
+	public void testIntersectionWithSubTickDuplicates() {
 
-        Double[] leftTimes = {1.0, 1.53, 3.0};
-        Double[] rightTimes = {0.5, 1.5};
+		Double[] leftTimes = {1.0, 1.53, 3.0};
+		Double[] rightTimes = {0.5, 1.5};
 
-        TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes, 0.1).intersect(new TimeDiscretization(rightTimes, 0.1));
+		TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes, 0.1).intersect(new TimeDiscretization(rightTimes, 0.1));
 
-        assertThat(intersection.getAsDoubleArray(), is(equalTo(new double[]{1.5})));
-    }
+		assertThat(intersection.getAsDoubleArray(), is(equalTo(new double[]{1.5})));
+	}
 
-    @Test
-    public void testIntersectionWithDifferentTickSizes() {
+	@Test
+	public void testIntersectionWithDifferentTickSizes() {
 
-        Double[] leftTimes = {7.0, 3.0, 5.0, 3.0};
-        Double[] rightTimes = {5.0, 3.0, 1.0, 8.0, 0.0, 0.0, 8.0};
+		Double[] leftTimes = {7.0, 3.0, 5.0, 3.0};
+		Double[] rightTimes = {5.0, 3.0, 1.0, 8.0, 0.0, 0.0, 8.0};
 
-        TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes, 0.1).intersect(new TimeDiscretization(rightTimes, 1.0));
+		TimeDiscretizationInterface intersection = new TimeDiscretization(leftTimes, 0.1).intersect(new TimeDiscretization(rightTimes, 1.0));
 
-        assertThat(intersection.getTickSize(), is(equalTo(1.0)));
-    }
+		assertThat(intersection.getTickSize(), is(equalTo(1.0)));
+	}
 }


### PR DESCRIPTION
See finmath-lib issue #58

We unify duplicate removal and tick size rounding in TimeDiscretization
Building upon that we define unions and intersections of discretizations

### What is this PR for?
Unifying the handling of tick sizes and duplicates in the `TimeDiscretization` class in order to add unions and intersections to the `TimeDiscretizationInterface`.

### What type of PR is it?
Bug Fix, Refactor and Feature

### Todos
* I would suggest revisiting retrieving the default tick size from a system property, as now it can be set when constructing the `TimeDiscretization`. It makes the thing harder to test and it might clash when two dependencies both use finmath with different tick sizes.

### What is the related issue?
https://github.com/finmath/finmath-lib/issues/58

### How should this be tested?
Unit tests are provided

### Screenshots


### Questions:

**Does the licenses files need update?**

NO
 
**Are there breaking changes for older versions?**

YES
If there was any reliance on duplicates or unrounded time points. I ran the whole unit test suite and it didn’t seem to be the case there.

**Does the change require additional documentation?**

NO
