### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,9 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven.compiler-plugin.version}</version>
+				<configuration>
+					<fork>true</fork>
+				</configuration>
 			</plugin>
 
 			<plugin>
@@ -522,6 +525,7 @@
 							<source>11</source>
 							<target>11</target>
 							<compilerVersion>11</compilerVersion>
+					<fork>true</fork>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -548,6 +552,7 @@
 							<source>1.8</source>
 							<target>1.8</target>
 							<compilerVersion>1.8</compilerVersion>
+					<fork>true</fork>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
