### PR TITLE
Fix blackScholesOptionTheta

### DIFF
--- a/src/main/java/net/finmath/functions/AnalyticFormulas.java
+++ b/src/main/java/net/finmath/functions/AnalyticFormulas.java
@@ -613,7 +613,7 @@ public class AnalyticFormulas {
 			final double dPlus = (Math.log(initialStockValue / optionStrike) + (riskFreeRate + 0.5 * volatility * volatility) * optionMaturity) / (volatility * Math.sqrt(optionMaturity));
 			final double dMinus = dPlus - volatility * Math.sqrt(optionMaturity);
 
-			final double theta = volatility * Math.exp(-0.5*dPlus*dPlus) / Math.sqrt(2.0 * Math.PI) / Math.sqrt(optionMaturity) / 2 * initialStockValue + riskFreeRate * optionStrike * Math.exp(-riskFreeRate * optionMaturity) * NormalDistribution.cumulativeDistribution(dMinus);
+			final double theta = -volatility * Math.exp(-0.5*dPlus*dPlus) / Math.sqrt(2.0 * Math.PI) / Math.sqrt(optionMaturity) / 2 * initialStockValue - riskFreeRate * optionStrike * Math.exp(-riskFreeRate * optionMaturity) * NormalDistribution.cumulativeDistribution(dMinus);
 
 			return theta;
 		}


### PR DESCRIPTION
The calculation of theta for a Black Scholes option is wrong. The current result must be multiplied by -1. I propose to change line 616.

### What is this PR for?
*Replace this line by a few sentences describing the overall goals of the pull request's commits.*

### What type of PR is it?
Bug fix

### Todos
None

### What is the related issue?
theta is wrong

### How should this be tested?
just compare with the closed form formula

### Screenshots
<img width="362" alt="immagine" src="https://user-images.githubusercontent.com/13275362/168086078-76f5965e-637e-40d8-aacf-ae59e41c889f.png">


### Questions:

**Does the licenses files need update?**

No
 
**Are there breaking changes for older versions?**

No

**Does the change require additional documentation?**

No
