### PR TITLE
Use separate locks for cloned objects of CurveInterpolation

### DIFF
--- a/src/main/java8/net/finmath/marketdata/model/curves/CurveInterpolation.java
+++ b/src/main/java8/net/finmath/marketdata/model/curves/CurveInterpolation.java
@@ -535,6 +535,7 @@ public class CurveInterpolation extends AbstractCurve implements Serializable, C
 
 		newCurve.points					= new ArrayList<>();
 		newCurve.pointsBeingParameters	= new ArrayList<>();
+		newCurve.rationalFunctionInterpolationLazyInitLock = new Object();
 		newCurve.rationalFunctionInterpolation = null;
 		newCurve.curveCacheReference = null;
 		for(final Point point : points) {


### PR DESCRIPTION
### What is this PR for?
CurveInterpolation class was using same lock on all cloned objects despite they had own copy of the data. Perhaps making a deep copy of the lock is missed out. Consequently, it introduces significant lock contention at times. The issue is solved by having a deep copy of the lock in the clone() method so that each cloned object have its own copy of the lock.

### What type of PR is it?
Bug Fix | Improvement 

### Todos
N/A.

### What is the related issue?
N/A

### How should this be tested?
UnitTests are sufficient.

### Screenshots


### Questions:

**Does the licenses files need update?**

*No*
 
**Are there breaking changes for older versions?**

*No*

**Does the change require additional documentation?**

*No*
