### PR TITLE
ShortRateModel extends TermstructureModel fix short rate calibration

### DIFF
--- a/src/main/java/net/finmath/montecarlo/interestrate/ShortRateModel.java
+++ b/src/main/java/net/finmath/montecarlo/interestrate/ShortRateModel.java
@@ -14,7 +14,7 @@ import net.finmath.montecarlo.interestrate.models.covariance.ShortRateVolatility
  * @author Christian Fries
  * @version 1.0
  */
-public interface ShortRateModel {
+public interface ShortRateModel extends TermStructureModel{
 
 	/**
 	 * Create a new object implementing ShortRateModel, using the new volatility model.

--- a/src/main/java/net/finmath/montecarlo/interestrate/models/covariance/AbstractShortRateVolatilityModelParametric.java
+++ b/src/main/java/net/finmath/montecarlo/interestrate/models/covariance/AbstractShortRateVolatilityModelParametric.java
@@ -328,9 +328,9 @@ public abstract class AbstractShortRateVolatilityModelParametric extends Abstrac
 
 				// Create a HullWhiteModel with the new volatility structure.
 				// TODO the case has be removed after the interface has been refactored:
-				final HullWhiteModel model = (HullWhiteModel)calibrationModel.getCloneWithModifiedVolatilityModel(calibrationVolatilityModel);
+				final ShortRateModel model = calibrationModel.getCloneWithModifiedVolatilityModel(calibrationVolatilityModel);
 				final EulerSchemeFromProcessModel process = new EulerSchemeFromProcessModel(model, brownianMotion);
-				final LIBORMonteCarloSimulationFromLIBORModel modelMonteCarloSimulation = new LIBORMonteCarloSimulationFromLIBORModel(model, process);
+				final LIBORMonteCarloSimulationFromLIBORModel modelMonteCarloSimulation = new LIBORMonteCarloSimulationFromLIBORModel(process);
 
 				final ArrayList<Future<RandomVariable>> valueFutures = new ArrayList<>(calibrationProducts.length);
 				for(int calibrationProductIndex=0; calibrationProductIndex<calibrationProducts.length; calibrationProductIndex++) {


### PR DESCRIPTION
### What is this PR for?
Fix an error in AbstractShortRateVolatilityModelParametric that allows only the HullWhiteModel to be calibrated.

### What type of PR is it?
*Replace this line by any of { Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring }*

### Todos
*Remove this line and add todos if necessary. Otherwise put N/A here.*
* Further cleanup of the class is needed

### What is the related issue?
*Replace this line with a link to the corresponding issue (open an issue at github). Otherwise put N/A here.*

### How should this be tested?
*Replace this line with an outline the steps to test the PR here. Are UnitTests sufficient?*

### Screenshots


### Questions:

**Does the licenses files need update?**

*Replace this line by either YES or NO. Add details if required.*
 
**Are there breaking changes for older versions?**

*Replace this line by either YES or NO. Add details if required.*

**Does the change require additional documentation?**

*Replace this line by either YES or NO. Add details if required.*
