### PR TITLE
EuropeanOption

### DIFF
--- a/src/main/java/net/finmath/finitedifference/products/EuropeanOption.java
+++ b/src/main/java/net/finmath/finitedifference/products/EuropeanOption.java
@@ -1,0 +1,179 @@
+package net.finmath.finitedifference.products;
+
+import net.finmath.finitedifference.models.FiniteDifference1DBoundary;
+import net.finmath.finitedifference.models.FiniteDifference1DModel;
+import net.finmath.modelling.products.CallOrPut;
+
+
+/**
+ * Implements valuation of a European option on a single asset.
+ *
+ * Given a model for an asset <i>S</i>, the European option with strike <i>K</i>, maturity <i>T</i>
+ * pays
+ * <br>
+ * 	<i>max((S(T) - K) * CallOrPut , 0)</i> in <i>T</i>
+ * <br>
+ *
+ * The class implements the characteristic function of the call option
+ * payoff, i.e., its Fourier transform.
+ *
+ * @author Christian Fries
+ * @author Ralph Rudd
+ * @author Alessandro Gnoatto
+ * @version 1.0
+ */
+public class EuropeanOption implements FiniteDifference1DProduct, FiniteDifference1DBoundary{
+
+	private final String underlyingName;
+	private final double maturity;
+	private final double strike;
+	private final CallOrPut callOrPutSign;
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(sign * (S(T)-K),0).
+	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final double callOrPutSign) {
+		super();
+		this.underlyingName	= underlyingName;
+		this.maturity		= maturity;
+		this.strike			= strike;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(sign * (S(T)-K),0).
+	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final CallOrPut callOrPutSign) {
+		super();
+		this.underlyingName	= underlyingName;
+		this.maturity		= maturity;
+		this.strike			= strike;
+		this.callOrPutSign	= callOrPutSign;
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 * @param underlyingIndex The index of the underlying to be fetched from the model.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final double callOrPutSign) {
+		super();
+		this.maturity			= maturity;
+		this.strike				= strike;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
+		this.underlyingName	= null;		// Use underlyingIndex
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 * @param underlyingIndex The index of the underlying to be fetched from the model.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final CallOrPut callOrPutSign) {
+		super();
+		this.maturity			= maturity;
+		this.strike				= strike;
+		this.callOrPutSign		= callOrPutSign;
+		this.underlyingName	= null;		// Use underlyingIndex
+	}
+	
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike) {
+		this(underlyingName, maturity, strike, 1.0);
+	}
+
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 */
+	public EuropeanOption(final double maturity, final double strike) {
+		this(maturity, strike, 1.0);
+	}
+
+	@Override
+	public double[][] getValue(final double evaluationTime, final FiniteDifference1DModel model) {
+
+		/*
+		 * The FDM algorithm requires the boundary conditions of the product.
+		 * This product implements the boundary interface
+		 */
+		final FiniteDifference1DBoundary boundary = this;
+		
+		if(callOrPutSign == CallOrPut.CALL) {
+			return model.getValue(evaluationTime, maturity, assetValue ->  Math.max(assetValue - strike, 0), boundary);
+		}else {
+			return model.getValue(evaluationTime, maturity, assetValue ->  Math.max(strike - assetValue, 0), boundary);
+		}
+	}
+
+	/*
+	 * Implementation of the interface:
+	 * @see net.finmath.finitedifference.products.FiniteDifference1DBoundary#getValueAtLowerBoundary(net.finmath.finitedifference.models.FDMBlackScholesModel, double, double)
+	 */
+	@Override
+	public double getValueAtLowerBoundary(final FiniteDifference1DModel model, final double currentTime, final double stockPrice) {
+		if(callOrPutSign == CallOrPut.CALL) {
+			return 0;
+		}else {
+			return strike * Math.exp(-model.getRiskFreeRate()*(maturity - currentTime));
+		}
+	}
+
+	@Override
+	public double getValueAtUpperBoundary(final FiniteDifference1DModel model, final double currentTime, final double stockPrice) {
+		if(callOrPutSign == CallOrPut.CALL) {
+			return stockPrice - strike * Math.exp(-model.getRiskFreeRate()*(maturity - currentTime));
+		}else {
+			return 0.0;
+		}
+		
+	}
+
+	public String getUnderlyingName() {
+		return underlyingName;
+	}
+
+	public double getMaturity() {
+		return maturity;
+	}
+
+	public double getStrike() {
+		return strike;
+	}
+
+	public CallOrPut getCallOrPutSign() {
+		return callOrPutSign;
+	}
+
+}

--- a/src/main/java/net/finmath/finitedifference/products/FDMEuropeanCallOption.java
+++ b/src/main/java/net/finmath/finitedifference/products/FDMEuropeanCallOption.java
@@ -7,11 +7,14 @@ import net.finmath.finitedifference.models.FiniteDifference1DModel;
 
 /**
  * Implementation of a European option to be valued by a the finite difference method.
+ * 
+ * WARNING!! This class is scheduled for deletion in a future release. Use EuropeanOption.
  *
  * @author Christian Fries
  * @author Ralph Rudd
  * @version 1.0
  */
+@Deprecated
 public class FDMEuropeanCallOption implements FiniteDifference1DProduct, FiniteDifference1DBoundary {
 	private final double maturity;
 	private final double strike;

--- a/src/main/java/net/finmath/finitedifference/products/FDMEuropeanPutOption.java
+++ b/src/main/java/net/finmath/finitedifference/products/FDMEuropeanPutOption.java
@@ -6,9 +6,12 @@ import net.finmath.finitedifference.models.FiniteDifference1DModel;
 /**
  * Implementation of a European option to be valued by a the finite difference method.
  *
+ * WARNING!! This class is scheduled for deletion in a future release. Use EuropeanOption.
+ *
  * @author Christian Fries
  * @author Ralph Rudd
  */
+@Deprecated
 public class FDMEuropeanPutOption implements FiniteDifference1DProduct, FiniteDifference1DBoundary {
 	private final double maturity;
 	private final double strike;

--- a/src/main/java/net/finmath/fouriermethod/models/BatesModel.java
+++ b/src/main/java/net/finmath/fouriermethod/models/BatesModel.java
@@ -395,10 +395,27 @@ public class BatesModel implements CharacteristicFunctionModel {
 	}
 
 	/**
+	 * @return the discountCurveForForwardRate
+	 */
+	@Override
+	public DiscountCurve getDiscountCurveForForwardRate() {
+		return discountCurveForForwardRate;
+	}
+
+	/**
 	 * @return the riskFreeRate
 	 */
+	@Override
 	public double getRiskFreeRate() {
 		return riskFreeRate;
+	}
+
+	/**
+	 * @return the discountCurveForDiscountRate
+	 */
+	@Override
+	public DiscountCurve getDiscountCurveForDiscountRate() {
+		return discountCurveForDiscountRate;
 	}
 
 	/**

--- a/src/main/java/net/finmath/fouriermethod/models/BlackScholesModel.java
+++ b/src/main/java/net/finmath/fouriermethod/models/BlackScholesModel.java
@@ -129,6 +129,7 @@ public class BlackScholesModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the referenceDate
 	 */
+	@Override
 	public LocalDate getReferenceDate() {
 		return referenceDate;
 	}
@@ -136,6 +137,7 @@ public class BlackScholesModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the initialValue
 	 */
+	@Override
 	public double getInitialValue() {
 		return initialValue;
 	}

--- a/src/main/java/net/finmath/fouriermethod/models/CharacteristicFunctionModel.java
+++ b/src/main/java/net/finmath/fouriermethod/models/CharacteristicFunctionModel.java
@@ -6,7 +6,10 @@
 
 package net.finmath.fouriermethod.models;
 
+import java.time.LocalDate;
+
 import net.finmath.fouriermethod.CharacteristicFunction;
+import net.finmath.marketdata.model.curves.DiscountCurve;
 import net.finmath.modelling.Model;
 
 /**
@@ -16,7 +19,6 @@ import net.finmath.modelling.Model;
  * @author Christian Fries
  * @version 1.0
  */
-@FunctionalInterface
 public interface CharacteristicFunctionModel extends Model {
 
 	/**
@@ -26,4 +28,37 @@ public interface CharacteristicFunctionModel extends Model {
 	 * @return The characteristic function of X(t).
 	 */
 	CharacteristicFunction apply(double time);
+
+	/**
+	 * 
+	 * @return the reference date
+	 */
+	public LocalDate getReferenceDate();
+
+	/**
+	 * 
+	 * @return the initial value of the stock
+	 */
+	public double getInitialValue();
+
+	/**
+	 * @return the discountCurveForForwardRate
+	 */
+	public DiscountCurve getDiscountCurveForForwardRate();
+
+	/**
+	 * @return the riskFreeRate
+	 */
+	public double getRiskFreeRate();
+
+	/**
+	 * @return the discountCurveForDiscountRate
+	 */
+	public DiscountCurve getDiscountCurveForDiscountRate();
+
+	/**
+	 * @return the discountRate
+	 */
+	public double getDiscountRate();
+
 }

--- a/src/main/java/net/finmath/fouriermethod/models/HestonModel.java
+++ b/src/main/java/net/finmath/fouriermethod/models/HestonModel.java
@@ -209,6 +209,7 @@ public class HestonModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the referenceDate
 	 */
+	@Override
 	public LocalDate getReferenceDate() {
 		return referenceDate;
 	}
@@ -216,6 +217,7 @@ public class HestonModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the initialValue
 	 */
+	@Override
 	public double getInitialValue() {
 		return initialValue;
 	}
@@ -223,6 +225,7 @@ public class HestonModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the discountCurveForForwardRate
 	 */
+	@Override
 	public DiscountCurve getDiscountCurveForForwardRate() {
 		return discountCurveForForwardRate;
 	}
@@ -230,6 +233,7 @@ public class HestonModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the riskFreeRate
 	 */
+	@Override
 	public double getRiskFreeRate() {
 		return riskFreeRate;
 	}
@@ -237,6 +241,7 @@ public class HestonModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the discountCurveForDiscountRate
 	 */
+	@Override
 	public DiscountCurve getDiscountCurveForDiscountRate() {
 		return discountCurveForDiscountRate;
 	}
@@ -244,6 +249,7 @@ public class HestonModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the discountRate
 	 */
+	@Override
 	public double getDiscountRate() {
 		return discountRate;
 	}

--- a/src/main/java/net/finmath/fouriermethod/models/MertonModel.java
+++ b/src/main/java/net/finmath/fouriermethod/models/MertonModel.java
@@ -168,6 +168,7 @@ public class MertonModel implements CharacteristicFunctionModel{
 	/**
 	 * @return the referenceDate
 	 */
+	@Override
 	public LocalDate getReferenceDate() {
 		return referenceDate;
 	}
@@ -175,6 +176,7 @@ public class MertonModel implements CharacteristicFunctionModel{
 	/**
 	 * @return the initialValue
 	 */
+	@Override
 	public double getInitialValue() {
 		return initialValue;
 	}
@@ -182,6 +184,7 @@ public class MertonModel implements CharacteristicFunctionModel{
 	/**
 	 * @return the discountCurveForForwardRate
 	 */
+	@Override
 	public DiscountCurve getDiscountCurveForForwardRate() {
 		return discountCurveForForwardRate;
 	}
@@ -189,6 +192,7 @@ public class MertonModel implements CharacteristicFunctionModel{
 	/**
 	 * @return the riskFreeRate
 	 */
+	@Override
 	public double getRiskFreeRate() {
 		return riskFreeRate;
 	}
@@ -196,6 +200,7 @@ public class MertonModel implements CharacteristicFunctionModel{
 	/**
 	 * @return the discountCurveForDiscountRate
 	 */
+	@Override
 	public DiscountCurve getDiscountCurveForDiscountRate() {
 		return discountCurveForDiscountRate;
 	}
@@ -203,6 +208,7 @@ public class MertonModel implements CharacteristicFunctionModel{
 	/**
 	 * @return the discountRate
 	 */
+	@Override
 	public double getDiscountRate() {
 		return discountRate;
 	}

--- a/src/main/java/net/finmath/fouriermethod/models/VarianceGammaModel.java
+++ b/src/main/java/net/finmath/fouriermethod/models/VarianceGammaModel.java
@@ -125,8 +125,8 @@ public class VarianceGammaModel implements CharacteristicFunctionModel {
 
 	/**
 	 * @return the referenceDate: The date corresponding to t = 0 (when dealing with {@link FloatingpointDate}s.
-
 	 */
+	@Override
 	public LocalDate getReferenceDate() {
 		return referenceDate;
 	}
@@ -134,6 +134,7 @@ public class VarianceGammaModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the initialValue
 	 */
+	@Override
 	public double getInitialValue() {
 		return initialValue;
 	}
@@ -141,6 +142,7 @@ public class VarianceGammaModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the discountCurveForForwardRate
 	 */
+	@Override
 	public DiscountCurve getDiscountCurveForForwardRate() {
 		return discountCurveForForwardRate;
 	}
@@ -148,6 +150,7 @@ public class VarianceGammaModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the riskFreeRate
 	 */
+	@Override
 	public double getRiskFreeRate() {
 		return riskFreeRate;
 	}
@@ -155,6 +158,7 @@ public class VarianceGammaModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the discountCurveForDiscountRate
 	 */
+	@Override
 	public DiscountCurve getDiscountCurveForDiscountRate() {
 		return discountCurveForDiscountRate;
 	}
@@ -162,6 +166,7 @@ public class VarianceGammaModel implements CharacteristicFunctionModel {
 	/**
 	 * @return the discountRate
 	 */
+	@Override
 	public double getDiscountRate() {
 		return discountRate;
 	}

--- a/src/main/java/net/finmath/fouriermethod/products/DigitalOption.java
+++ b/src/main/java/net/finmath/fouriermethod/products/DigitalOption.java
@@ -26,7 +26,7 @@ public class DigitalOption extends AbstractFourierTransformProduct {
 
 	private final double maturity;
 	private final double strike;
-	private final String nameOfUnderlying;
+	private final String underlyingName;
 
 	/**
 	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
@@ -37,7 +37,7 @@ public class DigitalOption extends AbstractFourierTransformProduct {
 		super();
 		this.maturity			= maturity;
 		this.strike				= strike;
-		nameOfUnderlying	= null;		// Use asset with index 0
+		underlyingName	= null;		// Use asset with index 0
 	}
 
 	/* (non-Javadoc)
@@ -59,6 +59,14 @@ public class DigitalOption extends AbstractFourierTransformProduct {
 	@Override
 	public double getMaturity() {
 		return maturity;
+	}
+
+	public double getStrike() {
+		return strike;
+	}
+
+	public String getUnderlyingName() {
+		return underlyingName;
 	}
 
 	/* (non-Javadoc)

--- a/src/main/java/net/finmath/fouriermethod/products/EuropeanOption.java
+++ b/src/main/java/net/finmath/fouriermethod/products/EuropeanOption.java
@@ -7,13 +7,17 @@ package net.finmath.fouriermethod.products;
 
 import org.apache.commons.math3.complex.Complex;
 
+import net.finmath.exception.CalculationException;
+import net.finmath.fouriermethod.models.CharacteristicFunctionModel;
+import net.finmath.modelling.products.CallOrPut;
+
 /**
  * Implements valuation of a European option on a single asset.
  *
  * Given a model for an asset <i>S</i>, the European option with strike <i>K</i>, maturity <i>T</i>
  * pays
  * <br>
- * 	<i>max(S(T) - K , 0)</i> in <i>T</i>
+ * 	<i>max((S(T) - K) * CallOrPut , 0)</i> in <i>T</i>
  * <br>
  *
  * The class implements the characteristic function of the call option
@@ -28,13 +32,90 @@ public class EuropeanOption extends AbstractFourierTransformProduct {
 	private final String underlyingName;
 	private final double maturity;
 	private final double strike;
+	private final CallOrPut callOrPutSign;
 
-	public EuropeanOption(final String underlyingName, final double maturity, final double strike) {
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(sign * (S(T)-K),0).
+	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final double callOrPutSign) {
 		super();
-		this.underlyingName = underlyingName;
-		this.maturity = maturity;
-		this.strike = strike;
+		this.underlyingName	= underlyingName;
+		this.maturity		= maturity;
+		this.strike			= strike;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
 	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(sign * (S(T)-K),0).
+	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final CallOrPut callOrPutSign) {
+		super();
+		this.underlyingName	= underlyingName;
+		this.maturity		= maturity;
+		this.strike			= strike;
+		this.callOrPutSign	= callOrPutSign;
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 * @param underlyingIndex The index of the underlying to be fetched from the model.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final double callOrPutSign) {
+		super();
+		this.maturity			= maturity;
+		this.strike				= strike;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
+		this.underlyingName	= null;		// Use underlyingIndex
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 * @param underlyingIndex The index of the underlying to be fetched from the model.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final CallOrPut callOrPutSign) {
+		super();
+		this.maturity			= maturity;
+		this.strike				= strike;
+		this.callOrPutSign		= callOrPutSign;
+		this.underlyingName	= null;		// Use underlyingIndex
+	}
+	
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike) {
+		this(underlyingName, maturity, strike, 1.0);
+	}
+
 
 	/**
 	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
@@ -42,8 +123,9 @@ public class EuropeanOption extends AbstractFourierTransformProduct {
 	 * @param strike The strike K in the option payoff max(S(T)-K,0).
 	 */
 	public EuropeanOption(final double maturity, final double strike) {
-		this(null, maturity, strike);
+		this(maturity, strike, 1.0);
 	}
+
 
 	@Override
 	public Complex apply(final Complex argument) {
@@ -56,8 +138,31 @@ public class EuropeanOption extends AbstractFourierTransformProduct {
 	}
 
 	@Override
+	public double getValue(final CharacteristicFunctionModel model) throws CalculationException {
+		if(callOrPutSign == CallOrPut.CALL) {
+			//It is a call, just use the existing implementation
+			return super.getValue(model);
+		}else {
+			double df = model.getDiscountCurveForDiscountRate() == null ? 
+					Math.exp(- model.getDiscountRate()) 
+					: model.getDiscountCurveForDiscountRate().getDiscountFactor(maturity);
+			//It is a put, use the put call parity
+			return super.getValue(model) - model.getInitialValue() + this.strike * df;
+		}
+		
+	}
+
+	public String getUnderlyingName() {
+		return underlyingName;
+	}
+
+	@Override
 	public double getMaturity() {
 		return maturity;
+	}
+
+	public double getStrike() {
+		return strike;
 	}
 
 	@Override

--- a/src/main/java/net/finmath/modelling/products/CallOrPut.java
+++ b/src/main/java/net/finmath/modelling/products/CallOrPut.java
@@ -1,7 +1,7 @@
 package net.finmath.modelling.products;
 
 /**
- * Defines once and for all for the library how we 
+ * Defines once and for all for the library how we
  * treat calls and puts via EuropeanOption classes.
  * 
  * @author Alessandro Gnoatto
@@ -12,7 +12,7 @@ public enum CallOrPut {
 
 	private final int value;
 
-	private CallOrPut(final int value) {
+	CallOrPut(final int value) {
 		this.value = value;
 	}
 
@@ -21,7 +21,7 @@ public enum CallOrPut {
 	 * @return 1 for a call and -1 for a put.
 	 */
 	public int toInteger() {
-        return value;
-    }
+		return value;
+	}
 
 }

--- a/src/main/java/net/finmath/modelling/products/CallOrPut.java
+++ b/src/main/java/net/finmath/modelling/products/CallOrPut.java
@@ -1,0 +1,27 @@
+package net.finmath.modelling.products;
+
+/**
+ * Defines once and for all for the library how we 
+ * treat calls and puts via EuropeanOption classes.
+ * 
+ * @author Alessandro Gnoatto
+ */
+public enum CallOrPut {
+	CALL(1),
+	PUT(-1);
+
+	private final int value;
+
+	private CallOrPut(final int value) {
+		this.value = value;
+	}
+
+	/**
+	 * Returns the sign associated to an option.
+	 * @return 1 for a call and -1 for a put.
+	 */
+	public int toInteger() {
+        return value;
+    }
+
+}

--- a/src/main/java/net/finmath/montecarlo/assetderivativevaluation/products/EuropeanOption.java
+++ b/src/main/java/net/finmath/montecarlo/assetderivativevaluation/products/EuropeanOption.java
@@ -145,6 +145,21 @@ public class EuropeanOption extends AbstractAssetMonteCarloProduct {
 	}
 
 	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final CallOrPut callOrPutSign) {
+		super();
+		this.maturity			= maturity;
+		this.strike				= strike;
+		this.callOrPutSign		= callOrPutSign;
+		this.underlyingIndex	= 0;
+		nameOfUnderliyng	= null;		// Use underlyingIndex
+	}
+
+	/**
 	 * This method returns the value random variable of the product within the specified model, evaluated at a given evalutationTime.
 	 * Note: For a lattice this is often the value conditional to evalutationTime, for a Monte-Carlo simulation this is the (sum of) value discounted to evaluation time.
 	 * Cashflows prior evaluationTime are not considered.

--- a/src/main/java/net/finmath/montecarlo/assetderivativevaluation/products/EuropeanOption.java
+++ b/src/main/java/net/finmath/montecarlo/assetderivativevaluation/products/EuropeanOption.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import net.finmath.exception.CalculationException;
 import net.finmath.modelling.Model;
+import net.finmath.modelling.products.CallOrPut;
 import net.finmath.montecarlo.assetderivativevaluation.AssetModelMonteCarloSimulationModel;
 import net.finmath.stochastic.RandomVariable;
 
@@ -19,7 +20,7 @@ import net.finmath.stochastic.RandomVariable;
  * Given a model for an asset <i>S</i>, the European option with strike <i>K</i>, maturity <i>T</i>
  * pays
  * <br>
- * 	<i>V(T) = max(S(T) - K , 0)</i> in <i>T</i>.
+ * 	<i>V(T) = max((S(T) - K) * CallOrPut , 0)</i> in <i>T</i>.
  * <br>
  *
  * The <code>getValue</code> method of this class will return the random variable <i>N(t) * V(T) / N(T)</i>,
@@ -34,7 +35,7 @@ public class EuropeanOption extends AbstractAssetMonteCarloProduct {
 
 	private final double maturity;
 	private final double strike;
-	private final double callOrPutSign;
+	private final CallOrPut callOrPutSign;
 	private final Integer underlyingIndex;
 	private final String nameOfUnderliyng;
 
@@ -46,6 +47,28 @@ public class EuropeanOption extends AbstractAssetMonteCarloProduct {
 	 * @param callOrPutSign The sign in the payoff.
 	 */
 	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final double callOrPutSign) {
+		super();
+		nameOfUnderliyng	= underlyingName;
+		this.maturity		= maturity;
+		this.strike			= strike;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
+		underlyingIndex		= 0;
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(sign * (S(T)-K),0).
+	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final CallOrPut callOrPutSign) {
 		super();
 		nameOfUnderliyng	= underlyingName;
 		this.maturity		= maturity;
@@ -65,7 +88,29 @@ public class EuropeanOption extends AbstractAssetMonteCarloProduct {
 		super();
 		this.maturity			= maturity;
 		this.strike				= strike;
-		this.callOrPutSign	= callOrPutSign;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
+		this.underlyingIndex	= underlyingIndex;
+		nameOfUnderliyng	= null;		// Use underlyingIndex
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 * @param underlyingIndex The index of the underlying to be fetched from the model.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final CallOrPut callOrPutSign, final int underlyingIndex) {
+		super();
+		this.maturity			= maturity;
+		this.strike				= strike;
+		this.callOrPutSign		= callOrPutSign;
 		this.underlyingIndex	= underlyingIndex;
 		nameOfUnderliyng	= null;		// Use underlyingIndex
 	}
@@ -117,7 +162,7 @@ public class EuropeanOption extends AbstractAssetMonteCarloProduct {
 		final RandomVariable underlyingAtMaturity	= model.getAssetValue(maturity, underlyingIndex);
 
 		// The payoff: values = max(underlying - strike, 0) = V(T) = max(S(T)-K,0)
-		RandomVariable values = underlyingAtMaturity.sub(strike).mult(callOrPutSign).floor(0.0);
+		RandomVariable values = underlyingAtMaturity.sub(strike).mult(callOrPutSign.toInteger()).floor(0.0);
 
 		// Discounting...
 		final RandomVariable numeraireAtMaturity	= model.getNumeraire(maturity);
@@ -158,6 +203,10 @@ public class EuropeanOption extends AbstractAssetMonteCarloProduct {
 
 	public double getStrike() {
 		return strike;
+	}
+
+	public CallOrPut getCallOrPut() {
+		return callOrPutSign;
 	}
 
 	public Integer getUnderlyingIndex() {

--- a/src/main/java/net/finmath/tree/assetderivativevaluation/products/AbstractNonPathDependentProduct.java
+++ b/src/main/java/net/finmath/tree/assetderivativevaluation/products/AbstractNonPathDependentProduct.java
@@ -14,12 +14,17 @@ import java.util.function.DoubleUnaryOperator;
  * (if any) and the backward induction logic are delegated to subclasses via
  * getValues(double, TreeModel).
  * 
+ * The payoff function is protected so that we can define specialized subclasses
+ * for the most important products. This is the approach followed in the class
+ * EuropeanOption
+ * 
  * @author Carlo Andrea Tramentozzi
+ * @author Alessandro Gnoatto
  */
 public abstract class AbstractNonPathDependentProduct extends AbstractTreeProduct {
 
 	/** Payoff function f(S) applied at maturity (or when exercised). */
-	private final DoubleUnaryOperator payOffFunction;
+	protected DoubleUnaryOperator payOffFunction;
 
 	/**
 	 * Creates a non–path-dependent option with a given maturity and payoff.
@@ -32,6 +37,11 @@ public abstract class AbstractNonPathDependentProduct extends AbstractTreeProduc
 	public AbstractNonPathDependentProduct(double maturity, DoubleUnaryOperator payOffFunction ){
 		super(maturity);
 		this.payOffFunction = payOffFunction;
+	}
+	
+	public AbstractNonPathDependentProduct(double maturity){
+		super(maturity);
+		this.payOffFunction = null;
 	}
 
 	/**

--- a/src/main/java/net/finmath/tree/assetderivativevaluation/products/AbstractNonPathDependentProduct.java
+++ b/src/main/java/net/finmath/tree/assetderivativevaluation/products/AbstractNonPathDependentProduct.java
@@ -9,9 +9,7 @@ import java.util.function.DoubleUnaryOperator;
 
 /**
  * Base class for non–path-dependent options priced on a TreeModel.
- * The payoff is fully specified by a DoubleUnaryOperator acting on the spot
- * at maturity (e.g. s -> Math.max(s-K,0) for a call). Early–exercise features
- * (if any) and the backward induction logic are delegated to subclasses via
+ * Early–exercise features(if any) and the backward induction logic are delegated to subclasses via
  * getValues(double, TreeModel).
  * 
  * The payoff function is protected so that we can define specialized subclasses
@@ -23,25 +21,14 @@ import java.util.function.DoubleUnaryOperator;
  */
 public abstract class AbstractNonPathDependentProduct extends AbstractTreeProduct {
 
-	/** Payoff function f(S) applied at maturity (or when exercised). */
-	protected DoubleUnaryOperator payOffFunction;
-
 	/**
 	 * Creates a non–path-dependent option with a given maturity and payoff.
 	 *
 	 * @param maturity
 	 *        Contract maturity (model time units), typically T.
-	 * @param payOffFunction
-	 *        Payoff function f(S) (e.g. call/put); must not be null.
 	 */
-	public AbstractNonPathDependentProduct(double maturity, DoubleUnaryOperator payOffFunction ){
-		super(maturity);
-		this.payOffFunction = payOffFunction;
-	}
-	
 	public AbstractNonPathDependentProduct(double maturity){
 		super(maturity);
-		this.payOffFunction = null;
 	}
 
 	/**
@@ -49,9 +36,7 @@ public abstract class AbstractNonPathDependentProduct extends AbstractTreeProduc
 	 *
 	 * @return The payoff function.
 	 */
-	protected DoubleUnaryOperator getPayOffFunction(){
-		return payOffFunction;
-	}
+	public abstract DoubleUnaryOperator getPayOffFunction();
 
 	/**
 	 * Converts a model time to the corresponding lattice time index by rounding

--- a/src/main/java/net/finmath/tree/assetderivativevaluation/products/AmericanNonPathDependent.java
+++ b/src/main/java/net/finmath/tree/assetderivativevaluation/products/AmericanNonPathDependent.java
@@ -17,6 +17,8 @@ import java.util.function.DoubleUnaryOperator;
  */
 public class AmericanNonPathDependent extends AbstractNonPathDependentProduct {
 
+	private final DoubleUnaryOperator payOffFunction;
+
 	/**
 	 * Creates an American option with given maturity and payoff.
 	 *
@@ -24,7 +26,8 @@ public class AmericanNonPathDependent extends AbstractNonPathDependentProduct {
 	 * @param payOffFunction  Payoff function f(S) (e.g.,s -> Math.max(K - s, 0.0) for a put).
 	 */
 	public AmericanNonPathDependent(double maturity, DoubleUnaryOperator payOffFunction) {
-		super(maturity, payOffFunction);
+		super(maturity);
+		this.payOffFunction = payOffFunction;
 	}
 
 	/**
@@ -59,6 +62,11 @@ public class AmericanNonPathDependent extends AbstractNonPathDependentProduct {
 
 		return levels;
 
+	}
+
+	@Override
+	public DoubleUnaryOperator getPayOffFunction() {
+		return this.payOffFunction;
 	}
 }
 

--- a/src/main/java/net/finmath/tree/assetderivativevaluation/products/EuropeanNonPathDependent.java
+++ b/src/main/java/net/finmath/tree/assetderivativevaluation/products/EuropeanNonPathDependent.java
@@ -13,6 +13,7 @@ import java.util.function.DoubleUnaryOperator;
  */
 public class EuropeanNonPathDependent extends AbstractNonPathDependentProduct {
 
+	private final DoubleUnaryOperator payOffFunction;
 	/**
 	 * Creates a European option with given maturity and payoff.
 	 *
@@ -21,7 +22,8 @@ public class EuropeanNonPathDependent extends AbstractNonPathDependentProduct {
 	 *                        (e.g., s -> Math.max(s-K,0.0) for a call).
 	 */
 	public EuropeanNonPathDependent(double maturity, DoubleUnaryOperator payOffFunction){
-		super(maturity,payOffFunction);
+		super(maturity);
+		this.payOffFunction = payOffFunction;
 	}
 
 	/**
@@ -45,5 +47,9 @@ public class EuropeanNonPathDependent extends AbstractNonPathDependentProduct {
 		return values;
 	}
 
+	@Override
+	public DoubleUnaryOperator getPayOffFunction() {
+		return this.payOffFunction;
 	}
 
+}

--- a/src/main/java/net/finmath/tree/assetderivativevaluation/products/EuropeanOption.java
+++ b/src/main/java/net/finmath/tree/assetderivativevaluation/products/EuropeanOption.java
@@ -1,0 +1,181 @@
+package net.finmath.tree.assetderivativevaluation.products;
+
+import java.util.function.DoubleUnaryOperator;
+
+import net.finmath.modelling.products.CallOrPut;
+import net.finmath.stochastic.RandomVariable;
+import net.finmath.tree.TreeModel;
+
+/**
+ * Implements the valuation of a European option on a single asset.
+ *
+ * Given a model for an asset <i>S</i>, the European option with strike <i>K</i>, maturity <i>T</i>
+ * pays
+ * <br>
+ * 	<i>V(T) = max((S(T) - K) * CallOrPut , 0)</i> in <i>T</i>.
+ * <br>
+ *
+ * @author Alessandro Gnoatto
+ */
+public class EuropeanOption extends AbstractNonPathDependentProduct {
+	private final double maturity;
+	private final double strike;
+	private final CallOrPut callOrPutSign;
+	private final String underlyingName;
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(sign * (S(T)-K),0).
+	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final double callOrPutSign) {	
+		super(maturity);
+		this.underlyingName	= underlyingName;
+		this.maturity		= maturity;
+		this.strike			= strike;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
+		if(this.callOrPutSign == CallOrPut.CALL) {
+			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
+		}else {
+			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
+		}
+		
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(sign * (S(T)-K),0).
+	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
+	 * @param callOrPutSign The sign in the payoff.
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final CallOrPut callOrPutSign) {
+		super(maturity);
+		this.underlyingName	= underlyingName;
+		this.maturity		= maturity;
+		this.strike			= strike;
+		this.callOrPutSign	= callOrPutSign;
+		if(this.callOrPutSign == CallOrPut.CALL) {
+			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
+		}else {
+			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
+		}
+
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 * @param underlyingIndex The index of the underlying to be fetched from the model.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final double callOrPutSign) {
+		super(maturity);
+		this.maturity			= maturity;
+		this.strike				= strike;
+		if(callOrPutSign == 1.0) {
+			this.callOrPutSign = CallOrPut.CALL;
+		}else if(callOrPutSign == - 1.0) {
+			this.callOrPutSign = CallOrPut.PUT;
+		}else {
+			throw new IllegalArgumentException("Unknown option type");
+		}
+		this.underlyingName	= null;		// Use underlyingIndex
+		if(this.callOrPutSign == CallOrPut.CALL) {
+			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
+		}else {
+			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
+		}
+
+	}
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 * @param callOrPutSign The sign in the payoff.
+	 * @param underlyingIndex The index of the underlying to be fetched from the model.
+	 */
+	public EuropeanOption(final double maturity, final double strike, final CallOrPut callOrPutSign) {
+		super(maturity);
+		this.maturity			= maturity;
+		this.strike				= strike;
+		this.callOrPutSign		= callOrPutSign;
+		this.underlyingName	= null;		// Use underlyingIndex
+		if(this.callOrPutSign == CallOrPut.CALL) {
+			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
+		}else {
+			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
+		}
+
+	}
+	
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
+	 * @param underlyingName Name of the underlying
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 */
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike) {
+		this(underlyingName, maturity, strike, 1.0);
+	}
+
+
+	/**
+	 * Construct a product representing an European option on an asset S (where S the asset with index 0 from the model - single asset case).
+	 * @param maturity The maturity T in the option payoff max(S(T)-K,0)
+	 * @param strike The strike K in the option payoff max(S(T)-K,0).
+	 */
+	public EuropeanOption(final double maturity, final double strike) {
+		this(maturity, strike, 1.0);
+	}
+
+	@Override
+	protected DoubleUnaryOperator getPayOffFunction(){
+		if(callOrPutSign == CallOrPut.CALL) {
+			return assetValue ->  Math.max(assetValue - strike, 0);
+		}else {
+			return assetValue ->  Math.max(strike - assetValue, 0);
+		}
+	}
+
+	@Override
+	public RandomVariable[] getValues(double evaluationTime, TreeModel model) {
+		final int k0  = timeToIndex(evaluationTime,model);
+		final int n = model.getNumberOfTimes()-1;
+		final RandomVariable[] values = new RandomVariable[n -k0 +1];
+		values[n-k0] = model.getTransformedValuesAtGivenTimeRV(model.getLastTime(),this.getPayOffFunction());
+
+		for (int timeIndex = n - 1; timeIndex >= k0; timeIndex--) {
+			values[timeIndex - k0] = model.getConditionalExpectationRV(values[(timeIndex+1)], timeIndex);
+		}
+		return values;
+
+	}
+
+	public double getMaturity() {
+		return maturity;
+	}
+
+	public double getStrike() {
+		return strike;
+	}
+
+	public CallOrPut getCallOrPutSign() {
+		return callOrPutSign;
+	}
+
+	public String getUnderlyingName() {
+		return underlyingName;
+	}
+
+}

--- a/src/main/java/net/finmath/tree/assetderivativevaluation/products/EuropeanOption.java
+++ b/src/main/java/net/finmath/tree/assetderivativevaluation/products/EuropeanOption.java
@@ -30,7 +30,7 @@ public class EuropeanOption extends AbstractNonPathDependentProduct {
 	 * @param strike The strike K in the option payoff max(sign * (S(T)-K),0).
 	 * @param callOrPutSign The sign in the payoff.
 	 */
-	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final double callOrPutSign) {	
+	public EuropeanOption(final String underlyingName, final double maturity, final double strike, final double callOrPutSign) {
 		super(maturity);
 		this.underlyingName	= underlyingName;
 		this.maturity		= maturity;
@@ -42,12 +42,6 @@ public class EuropeanOption extends AbstractNonPathDependentProduct {
 		}else {
 			throw new IllegalArgumentException("Unknown option type");
 		}
-		if(this.callOrPutSign == CallOrPut.CALL) {
-			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
-		}else {
-			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
-		}
-		
 	}
 
 	/**
@@ -63,12 +57,6 @@ public class EuropeanOption extends AbstractNonPathDependentProduct {
 		this.maturity		= maturity;
 		this.strike			= strike;
 		this.callOrPutSign	= callOrPutSign;
-		if(this.callOrPutSign == CallOrPut.CALL) {
-			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
-		}else {
-			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
-		}
-
 	}
 
 	/**
@@ -90,12 +78,6 @@ public class EuropeanOption extends AbstractNonPathDependentProduct {
 			throw new IllegalArgumentException("Unknown option type");
 		}
 		this.underlyingName	= null;		// Use underlyingIndex
-		if(this.callOrPutSign == CallOrPut.CALL) {
-			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
-		}else {
-			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
-		}
-
 	}
 
 	/**
@@ -111,14 +93,8 @@ public class EuropeanOption extends AbstractNonPathDependentProduct {
 		this.strike				= strike;
 		this.callOrPutSign		= callOrPutSign;
 		this.underlyingName	= null;		// Use underlyingIndex
-		if(this.callOrPutSign == CallOrPut.CALL) {
-			this.payOffFunction = assetValue ->  Math.max(assetValue - strike, 0);
-		}else {
-			this.payOffFunction = assetValue ->  Math.max(strike - assetValue, 0);
-		}
-
 	}
-	
+
 	/**
 	 * Construct a product representing an European option on an asset S (where S the asset with index <code>underlyingIndex</code> from the model - single asset case).
 	 * @param underlyingName Name of the underlying
@@ -140,7 +116,7 @@ public class EuropeanOption extends AbstractNonPathDependentProduct {
 	}
 
 	@Override
-	protected DoubleUnaryOperator getPayOffFunction(){
+	public DoubleUnaryOperator getPayOffFunction(){
 		if(callOrPutSign == CallOrPut.CALL) {
 			return assetValue ->  Math.max(assetValue - strike, 0);
 		}else {

--- a/src/test/java/net/finmath/finitedifference/BlackScholesThetaTest.java
+++ b/src/test/java/net/finmath/finitedifference/BlackScholesThetaTest.java
@@ -7,10 +7,10 @@ import org.junit.Test;
 
 import net.finmath.finitedifference.models.FDMBlackScholesModel;
 import net.finmath.finitedifference.models.FiniteDifference1DModel;
-import net.finmath.finitedifference.products.FDMEuropeanCallOption;
-import net.finmath.finitedifference.products.FDMEuropeanPutOption;
+import net.finmath.finitedifference.products.EuropeanOption;
 import net.finmath.finitedifference.products.FiniteDifference1DProduct;
 import net.finmath.functions.AnalyticFormulas;
+import net.finmath.modelling.products.CallOrPut;
 
 public class BlackScholesThetaTest {
 
@@ -36,7 +36,7 @@ public class BlackScholesThetaTest {
 				initialValue,
 				riskFreeRate,
 				volatility);
-		final FiniteDifference1DProduct callOption = new FDMEuropeanCallOption(optionMaturity, optionStrike);
+		final FiniteDifference1DProduct callOption = new EuropeanOption(optionMaturity, optionStrike, CallOrPut.CALL);
 
 		final double[][] valueCallFDM = callOption.getValue(0.0, model);
 		final double[] initialStockPriceForCall = valueCallFDM[0];
@@ -74,7 +74,7 @@ public class BlackScholesThetaTest {
 				initialValue,
 				riskFreeRate,
 				volatility);
-		final FiniteDifference1DProduct putOption = new FDMEuropeanPutOption(optionMaturity, optionStrike);
+		final FiniteDifference1DProduct putOption = new EuropeanOption(optionMaturity, optionStrike, CallOrPut.PUT);
 		final double[][] valuePutFDM = putOption.getValue(0.0, model);
 		final double[] initialStockPriceForPut = valuePutFDM[0];
 		final double[] putOptionValue = valuePutFDM[1];

--- a/src/test/java/net/finmath/fouriermethod/BlackScholesCallOptionTest.java
+++ b/src/test/java/net/finmath/fouriermethod/BlackScholesCallOptionTest.java
@@ -16,6 +16,7 @@ import net.finmath.fouriermethod.products.DigitalOption;
 import net.finmath.fouriermethod.products.EuropeanOption;
 import net.finmath.fouriermethod.products.FourierTransformProduct;
 import net.finmath.functions.AnalyticFormulas;
+import net.finmath.modelling.products.CallOrPut;
 
 /**
  * Test class for the valuation of a call option under Black Scholes
@@ -51,6 +52,27 @@ public class BlackScholesCallOptionTest {
 		System.out.println(product.getClass().getSimpleName() + "\t" + "Result: " + value + ". \tError: " + error + "." + ". \tCalculation time: " + ((endMillis-startMillis)/1000.0) + " sec.");
 
 		Assert.assertEquals("Value", valueAnalytic, value, 1E-7);
+	}
+
+	@Test
+	public void testPutCallParity() throws CalculationException {
+
+		final CharacteristicFunctionModel model = new BlackScholesModel(initialValue, riskFreeRate, volatility);
+
+		final FourierTransformProduct productCall = new EuropeanOption(maturity, strike);
+		final FourierTransformProduct productPut = new EuropeanOption(maturity, strike, CallOrPut.PUT);
+
+
+		final double valueCall			= productCall.getValue(model);
+		final double valuePut			= productPut.getValue(model);
+
+
+		final double rightHandSide	= valueCall - valuePut;
+
+		final double leftHandSide	= initialValue - strike * Math.exp(-riskFreeRate * maturity);
+
+
+		Assert.assertEquals("Value", rightHandSide, leftHandSide, 1E-7);
 	}
 
 	@Test

--- a/src/test/java/net/finmath/montecarlo/assetderivativevaluation/BlackScholesMonteCarloValuationTest.java
+++ b/src/test/java/net/finmath/montecarlo/assetderivativevaluation/BlackScholesMonteCarloValuationTest.java
@@ -21,6 +21,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 import net.finmath.exception.CalculationException;
+import net.finmath.modelling.products.CallOrPut;
 import net.finmath.montecarlo.BrownianMotionFromMersenneRandomNumbers;
 import net.finmath.montecarlo.RandomVariableFactory;
 import net.finmath.montecarlo.RandomVariableFromArrayFactory;
@@ -199,6 +200,7 @@ public class BlackScholesMonteCarloValuationTest {
 
 		// Test options with different strike
 		System.out.println("Valuation of European Options");
+		System.out.println("Call options");
 		System.out.println(" Strike \t Monte-Carlo \t Analytic \t Deviation");
 
 		/*
@@ -227,6 +229,28 @@ public class BlackScholesMonteCarloValuationTest {
 					"\t" + numberFormatDeviation.format(valueMonteCarlo-valueAnalytic));
 
 			Assert.assertTrue(Math.abs(valueMonteCarlo-valueAnalytic) < 1E-02);
+		}
+
+		System.out.println("Put options");
+		System.out.println(" Strike \t Monte-Carlo \t Analytic \t Deviation");
+		//Same check for puts
+		for(double optionStrike = 0.60; optionStrike < 1.50; optionStrike += 0.05) {
+
+			// Create a product
+			final EuropeanOption		putOption	= new EuropeanOption(optionMaturity, optionStrike, CallOrPut.PUT);
+			// Value the product with Monte Carlo
+			final double valueMonteCarlo	= putOption.getValue(model);
+
+			// Calculate the analytic value
+			final double valueAnalytic	= net.finmath.functions.AnalyticFormulas.blackScholesOptionValue(initialValue, riskFreeRate, volatility, optionMaturity, optionStrike);
+			final double putFromParity  = valueAnalytic -initialValue + optionStrike * Math.exp(-riskFreeRate * optionMaturity);
+			// Print result
+			System.out.println(numberFormatStrike.format(optionStrike) +
+					"\t" + numberFormatValue.format(valueMonteCarlo) +
+					"\t" + numberFormatValue.format(putFromParity) +
+					"\t" + numberFormatDeviation.format(valueMonteCarlo-putFromParity));
+
+			Assert.assertTrue(Math.abs(valueMonteCarlo-putFromParity) < 1E-02);
 		}
 	}
 

--- a/src/test/java/net/finmath/tree/EuropeanAndAmericanOptionPricingTest.java
+++ b/src/test/java/net/finmath/tree/EuropeanAndAmericanOptionPricingTest.java
@@ -4,10 +4,12 @@ package net.finmath.tree;
 import org.junit.Assert;
 import org.junit.Test;
 
+import net.finmath.modelling.products.CallOrPut;
 import net.finmath.tree.assetderivativevaluation.models.BoyleTrinomial;
 import net.finmath.tree.assetderivativevaluation.models.CoxRossRubinsteinModel;
 import net.finmath.tree.assetderivativevaluation.models.JarrowRuddModel;
 import net.finmath.tree.assetderivativevaluation.products.EuropeanNonPathDependent;
+import net.finmath.tree.assetderivativevaluation.products.EuropeanOption;
 import net.finmath.tree.assetderivativevaluation.products.AmericanNonPathDependent;
 
 public class EuropeanAndAmericanOptionPricingTest {
@@ -28,8 +30,7 @@ public class EuropeanAndAmericanOptionPricingTest {
 		BoyleTrinomial tri = new BoyleTrinomial(spot,rate,vol,maturity,steps);
 
 
-
-		EuropeanNonPathDependent euCall = new EuropeanNonPathDependent(maturity, s -> Math.max(s - strike, 0.0));
+		EuropeanOption euCall = new EuropeanOption(maturity, strike, CallOrPut.CALL);
 		AmericanNonPathDependent usCall = new AmericanNonPathDependent(maturity, s -> Math.max(s - strike, 0.0));
 
 
@@ -75,7 +76,7 @@ public class EuropeanAndAmericanOptionPricingTest {
 
 
 
-		EuropeanNonPathDependent euPut = new EuropeanNonPathDependent(maturity, s -> Math.max(strike - s, 0.0));
+		EuropeanOption euPut = new EuropeanOption(maturity, strike, CallOrPut.PUT);
 		AmericanNonPathDependent usPut = new AmericanNonPathDependent(maturity, s -> Math.max(strike - s, 0.0));
 
 


### PR DESCRIPTION
### What is this PR for?
Introduce a class EuropeanOption for every calculation engine of the library: Fourier, Trees, Finite Difference by following the scheme of EuropeanOption in net.finmath.assetderivativevalution.products - use the same convention everywhere.

### What type of PR is it?
* New functionalities

### Todos
*Remove this line and add todos if necessary. Otherwise put N/A here.*
* TODO: remove deprecated classes in the FDM framework.

### What is the related issue?
* Naming inconsistencies in the different framework. Confusing structure of the library.

### How should this be tested?
*Check that all existing unit tests are working, which I did.

### Screenshots


### Questions:

**Does the licenses files need update?**

*NO
 
**Are there breaking changes for older versions?**

*NO

**Does the change require additional documentation?**

*NO
